### PR TITLE
feat: default context hardening to false and require opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 ## [Unreleased]
 
-### Added — ContextBuilder `hardening` feature gate (default false, explicit opt-in required)
+### Added — ContextBuilder `hardening` feature gate with planner-first auxiliary sections (default false, explicit opt-in required)
 
 `config/memory.js`의 `contextInjection.hardeningEnabled`는 호환성 유지를 위해 기본값이 `false`다.
 
-- **`hardeningEnabled=false` (기본)**: 기존 동작 보존. `searchBySource` 미호출, `[LEARNING MEMORY]` 섹션 없음, `rankedInjection` anchor 필터 legacy (`f.type === "anchor"`).
-- **`hardeningEnabled=true` (명시적 opt-in)**: Closed Learning Loop 주입 (`[LEARNING MEMORY]` 섹션), `is_anchor=TRUE` 기반 정확한 anchor 고정.
-- `ContextBuilder` 생성자에 `hardeningEnabled` 옵션 추가 (테스트/DI용 직접 주입 지원).
-- `tests/unit/context-builder.test.js`: 19개 테스트 (기존 9 → 19). 신규 동작 테스트는 `hardeningEnabled: true` 명시, 회귀 테스트 4개 추가.
+- **`hardeningEnabled=false` (기본)**: 기존 bootstrap 중심 동작 보존. query-aware auxiliary section attach 비활성화, `rankedInjection` anchor 필터 legacy 유지.
+- **`hardeningEnabled=true` (명시적 opt-in)**: `contextText`, `caseId`, `resolutionStatus`, `phase`를 바탕으로 `AuxiliarySectionPlanner`가 보조 섹션을 고른다. 현재 구현된 보조 섹션은 `[LEARNING MEMORY]`, `[ERROR PLAYBOOK]`, `[DECISION MEMORY]`, `[OPEN QUESTIONS MEMORY]`, `[CASE MEMORY]`다.
+- planner는 LLM 우선으로 섹션을 선택하고, 실패 시 deterministic heuristic fallback으로 degrade한다.
+- 보조 섹션은 sparse render 방식이라 실제 매칭 결과가 있을 때만 출력된다. 빈 섹션 헤더는 출력하지 않는다.
+- `contextInjection.llmPlannerEnabled`, `maxAuxiliarySections`, `auxiliaryTokenBudget`, `caseMemoryMaxCases` 설정이 추가되었다.
+- `ContextBuilder` 생성자에 `hardeningEnabled`와 `auxiliaryPlanner` 주입 옵션이 추가되어 테스트/DI에서 planner 경로를 직접 제어할 수 있다.
+- 관련 회귀 테스트가 `tests/unit/context-builder.test.js`, `tests/unit/auxiliary-section-planner.test.js`, `tests/unit/context-structured.test.js`, `tests/unit/fragment-search-source-filter.test.js`에 추가 또는 확장되었다.
 
 ## [2.8.0] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Added — ContextBuilder `hardening` feature gate (default false, explicit opt-in required)
 
-`config/memory.js`의 `contextInjection.hardening.enabled`는 호환성 유지를 위해 기본값이 `false`다.
+`config/memory.js`의 `contextInjection.hardeningEnabled`는 호환성 유지를 위해 기본값이 `false`다.
 
-- **`hardening.enabled=false` (기본)**: 기존 동작 보존. `searchBySource` 미호출, `[LEARNING MEMORY]` 섹션 없음, `rankedInjection` anchor 필터 legacy (`f.type === "anchor"`).
-- **`hardening.enabled=true` (명시적 opt-in)**: Closed Learning Loop 주입 (`[LEARNING MEMORY]` 섹션), `is_anchor=TRUE` 기반 정확한 anchor 고정.
+- **`hardeningEnabled=false` (기본)**: 기존 동작 보존. `searchBySource` 미호출, `[LEARNING MEMORY]` 섹션 없음, `rankedInjection` anchor 필터 legacy (`f.type === "anchor"`).
+- **`hardeningEnabled=true` (명시적 opt-in)**: Closed Learning Loop 주입 (`[LEARNING MEMORY]` 섹션), `is_anchor=TRUE` 기반 정확한 anchor 고정.
 - `ContextBuilder` 생성자에 `hardeningEnabled` 옵션 추가 (테스트/DI용 직접 주입 지원).
 - `tests/unit/context-builder.test.js`: 19개 테스트 (기존 9 → 19). 신규 동작 테스트는 `hardeningEnabled: true` 명시, 회귀 테스트 4개 추가.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Added — ContextBuilder `hardening` feature gate (default false, explicit opt-in required)
+
+`config/memory.js`의 `contextInjection.hardening.enabled`는 호환성 유지를 위해 기본값이 `false`다.
+
+- **`hardening.enabled=false` (기본)**: 기존 동작 보존. `searchBySource` 미호출, `[LEARNING MEMORY]` 섹션 없음, `rankedInjection` anchor 필터 legacy (`f.type === "anchor"`).
+- **`hardening.enabled=true` (명시적 opt-in)**: Closed Learning Loop 주입 (`[LEARNING MEMORY]` 섹션), `is_anchor=TRUE` 기반 정확한 anchor 고정.
+- `ContextBuilder` 생성자에 `hardeningEnabled` 옵션 추가 (테스트/DI용 직접 주입 지원).
+- `tests/unit/context-builder.test.js`: 19개 테스트 (기존 9 → 19). 신규 동작 테스트는 `hardeningEnabled: true` 명시, 회귀 테스트 4개 추가.
+
 ## [2.8.0] - 2026-04-16
 
 ### Added — Symbolic Memory Layer (opt-in, 기본 전면 비활성)

--- a/config/memory.js
+++ b/config/memory.js
@@ -98,7 +98,7 @@ export const MEMORY_CONFIG = {
      *
      * 신규 동작이 필요한 소비자만 이 값을 명시적으로 true로 올려 opt-in 한다.
      */
-    hardening          : { enabled: false }
+    hardeningEnabled   : false
   },
   /** recall 페이지네이션 설정 */
   pagination: {

--- a/config/memory.js
+++ b/config/memory.js
@@ -89,7 +89,16 @@ export const MEMORY_CONFIG = {
     rankWeights        : {
       importance    : 0.6,
       ema_activation: 0.4
-    }
+    },
+    /**
+     * hardening 기능 플래그 (default: false — 호환성 우선 기본값)
+     *
+     * true : Closed Learning Loop 주입 + is_anchor 기반 anchor 필터 활성화
+     * false: 명시적 레거시 호환 모드 (learning 주입 없음, rankedInjection anchor 필터 legacy)
+     *
+     * 신규 동작이 필요한 소비자만 이 값을 명시적으로 true로 올려 opt-in 한다.
+     */
+    hardening          : { enabled: false }
   },
   /** recall 페이지네이션 설정 */
   pagination: {

--- a/config/memory.js
+++ b/config/memory.js
@@ -93,12 +93,25 @@ export const MEMORY_CONFIG = {
     /**
      * hardening 기능 플래그 (default: false — 호환성 우선 기본값)
      *
-     * true : Closed Learning Loop 주입 + is_anchor 기반 anchor 필터 활성화
+     * true : query-aware auxiliary memory 주입 + is_anchor 기반 anchor 필터 활성화
      * false: 명시적 레거시 호환 모드 (learning 주입 없음, rankedInjection anchor 필터 legacy)
      *
      * 신규 동작이 필요한 소비자만 이 값을 명시적으로 true로 올려 opt-in 한다.
      */
-    hardeningEnabled   : false
+    hardeningEnabled   : false,
+    /**
+     * hardening 경로에서 보조 섹션 선정을 LLM planner로 위임할지 여부.
+     *
+     * true : 질의/상황 signal 기반으로 auxiliary section 후보를 LLM이 선택
+     * false: deterministic heuristic fallback만 사용
+     */
+    llmPlannerEnabled  : true,
+    /** 한 번의 context() 응답에 붙일 최대 보조 섹션 수 */
+    maxAuxiliarySections: 2,
+    /** 보조 섹션 recall에 배정할 기본 토큰 예산 */
+    auxiliaryTokenBudget: 250,
+    /** case memory 섹션에서 최대 반환할 케이스 수 */
+    caseMemoryMaxCases : 2
   },
   /** recall 페이지네이션 설정 */
   pagination: {

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -224,7 +224,7 @@ export const MEMORY_CONFIG = {
     },
     // New feature gate (default: false — compatibility-first baseline)
     // Set to true to enable learning injection and is_anchor-based anchor ranking
-    hardening          : { enabled: false }
+    hardeningEnabled   : false
   },
   pagination: {
     defaultPageSize : 20,

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -223,8 +223,12 @@ export const MEMORY_CONFIG = {
       ema_activation: 0.4
     },
     // New feature gate (default: false — compatibility-first baseline)
-    // Set to true to enable learning injection and is_anchor-based anchor ranking
-    hardeningEnabled   : false
+    // Set to true to enable query-aware auxiliary memory + is_anchor-based anchor ranking
+    hardeningEnabled    : false,
+    llmPlannerEnabled   : true,  // Use LLM planner for auxiliary section selection
+    maxAuxiliarySections: 2,     // Max auxiliary sections per context() response
+    auxiliaryTokenBudget: 250,   // Default recall budget for one auxiliary section
+    caseMemoryMaxCases  : 2      // Max cases in CASE MEMORY
   },
   pagination: {
     defaultPageSize : 20,

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -217,7 +217,14 @@ export const MEMORY_CONFIG = {
       decision   : 3,
       fact       : 3
     },
-    defaultTokenBudget : 2000
+    defaultTokenBudget : 2000,
+    rankWeights        : {       // structured=true rankedInjection composite score weights (sum = 1.0)
+      importance    : 0.6,
+      ema_activation: 0.4
+    },
+    // New feature gate (default: false — compatibility-first baseline)
+    // Set to true to enable learning injection and is_anchor-based anchor ranking
+    hardening          : { enabled: false }
   },
   pagination: {
     defaultPageSize : 20,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -223,8 +223,12 @@ export const MEMORY_CONFIG = {
       ema_activation: 0.4
     },
     // 신규 기능 게이트 (default: false — 호환성 우선 기본값)
-    // true로 설정 시: Closed Learning Loop 주입 활성 + is_anchor 기반 anchor 필터 사용
-    hardeningEnabled   : false
+    // true로 설정 시: query-aware auxiliary memory + is_anchor 기반 anchor 필터 사용
+    hardeningEnabled    : false,
+    llmPlannerEnabled   : true,  // auxiliary section selection에 LLM planner 사용
+    maxAuxiliarySections: 2,     // 한 번에 붙일 보조 섹션 최대 수
+    auxiliaryTokenBudget: 250,   // 보조 섹션 recall 기본 예산
+    caseMemoryMaxCases  : 2      // CASE MEMORY 최대 case 수
   },
   pagination: {
     defaultPageSize : 20,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,7 +217,14 @@ export const MEMORY_CONFIG = {
       decision   : 3,
       fact       : 3
     },
-    defaultTokenBudget : 2000
+    defaultTokenBudget : 2000,
+    rankWeights        : {       // structured=true rankedInjection 복합 점수 가중치 (합계 1.0)
+      importance    : 0.6,
+      ema_activation: 0.4
+    },
+    // 신규 기능 게이트 (default: false — 호환성 우선 기본값)
+    // true로 설정 시: Closed Learning Loop 주입 활성 + is_anchor 기반 anchor 필터 사용
+    hardening          : { enabled: false }
   },
   pagination: {
     defaultPageSize : 20,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,7 +224,7 @@ export const MEMORY_CONFIG = {
     },
     // 신규 기능 게이트 (default: false — 호환성 우선 기본값)
     // true로 설정 시: Closed Learning Loop 주입 활성 + is_anchor 기반 anchor 필터 사용
-    hardening          : { enabled: false }
+    hardeningEnabled   : false
   },
   pagination: {
     defaultPageSize : 20,

--- a/docs/operations/local-source-deploy.md
+++ b/docs/operations/local-source-deploy.md
@@ -1,0 +1,37 @@
+# memento-mcp source/deploy workflow
+
+Canonical source clone:
+
+- `/Users/kunkun/memento-mcp`
+
+Live runtime service:
+
+- `/Users/kunkun/.adk/release/services/memento-mcp`
+- launchd label: `com.agentdesk.memento-mcp`
+- health URL: `http://127.0.0.1:57332/health`
+
+Bootstrap or repair the source clone:
+
+```bash
+/Users/kunkun/memento-mcp/scripts/bootstrap-memento-mcp-source.sh
+```
+
+Preview a deploy without touching the live runtime:
+
+```bash
+/Users/kunkun/memento-mcp/scripts/deploy-memento-mcp.sh --dry-run
+```
+
+Deploy source clone changes into the live runtime and restart the service:
+
+```bash
+/Users/kunkun/memento-mcp/scripts/deploy-memento-mcp.sh
+```
+
+Notes:
+
+- The deploy script syncs tracked files from the canonical clone into the live runtime.
+- The deploy defaults are derived from the repo location, so moving the clone does not require editing the script.
+- The deploy script runs `npm ci` from the synced lockfile before restart, so dependency resolution stays deterministic.
+- `config/memory.js` is preserved by default as a live-local override.
+- If the live runtime has tracked edits that differ from the source clone, deploy aborts unless `--allow-dirty-live` is passed.

--- a/lib/memory/AuxiliarySectionPlanner.js
+++ b/lib/memory/AuxiliarySectionPlanner.js
@@ -1,0 +1,173 @@
+/**
+ * AuxiliarySectionPlanner — query-aware auxiliary memory section selection
+ *
+ * hardening=true 컨텍스트 주입 경로에서
+ * user 질의 + 추가 signal(case/phase/resolution_status)을 바탕으로
+ * 어떤 보조 메모리 섹션을 붙일지 결정한다.
+ *
+ * 기본 경로:
+ *   1) LLM planner (llmJson)
+ *   2) 실패/비가용 시 heuristic fallback
+ */
+
+import { MEMORY_CONFIG } from "../../config/memory.js";
+import { llmJson, isLlmAvailable } from "../llm/index.js";
+import { logWarn } from "../logger.js";
+
+export const AUXILIARY_SECTION_CATALOG = {
+  learning_memory: {
+    title      : "LEARNING MEMORY",
+    description: "Prior extracted learnings relevant to the current user question or conversation context."
+  },
+  error_playbook: {
+    title      : "ERROR PLAYBOOK",
+    description: "Past error fragments and fix clues relevant to debugging, failures, or open issues."
+  },
+  decision_memory: {
+    title      : "DECISION MEMORY",
+    description: "Past architectural or product decisions relevant to planning, tradeoffs, or why-questions."
+  },
+  open_questions_memory: {
+    title      : "OPEN QUESTIONS MEMORY",
+    description: "Unresolved questions or pending follow-ups relevant to the current task."
+  },
+  case_memory: {
+    title      : "CASE MEMORY",
+    description: "Similar or same-case history that can guide the current situation."
+  }
+};
+
+const DEBUG_OR_ERROR_RE =
+  /(error|bug|fail|failure|debug|debugging|trace|exception|incident|issue|에러|버그|실패|디버그|예외|문제)/i;
+const DECISION_RE =
+  /(decision|tradeoff|design|architecture|approach|why|choose|choice|선택|결정|설계|구조|방식|이유)/i;
+const HISTORY_RE =
+  /(before|previous|prior|again|similar|history|past|이전에|전에|과거|비슷|다시)/i;
+const OPEN_QUESTION_RE =
+  /(unknown|unclear|question|todo|next step|blocked|uncertain|pending|미해결|질문|다음|막힘|불명확|확실하지)/i;
+
+function unique(items) {
+  return [...new Set(items)];
+}
+
+function sanitizeSections(sections, maxSections) {
+  if (!Array.isArray(sections)) return [];
+  return unique(
+    sections.filter((name) => Object.hasOwn(AUXILIARY_SECTION_CATALOG, name))
+  ).slice(0, maxSections);
+}
+
+export function buildHeuristicAuxiliaryPlan({
+  contextText = "",
+  caseId = null,
+  resolutionStatus = null,
+  phase = null,
+  maxSections = MEMORY_CONFIG.contextInjection?.maxAuxiliarySections || 2
+} = {}) {
+  const query = typeof contextText === "string" ? contextText.trim() : "";
+  const picks = [];
+
+  if (query) {
+    picks.push("learning_memory");
+  }
+  if (phase === "debugging" || resolutionStatus === "open" || DEBUG_OR_ERROR_RE.test(query)) {
+    picks.push("error_playbook");
+  }
+  if (phase === "planning" || DECISION_RE.test(query)) {
+    picks.push("decision_memory");
+  }
+  if (caseId || HISTORY_RE.test(query)) {
+    picks.push("case_memory");
+  }
+  if (resolutionStatus === "open" || OPEN_QUESTION_RE.test(query)) {
+    picks.push("open_questions_memory");
+  }
+
+  return {
+    sections : sanitizeSections(picks, maxSections),
+    source   : "heuristic",
+    rationale: "signal-based fallback"
+  };
+}
+
+export async function planAuxiliarySections({
+  contextText = "",
+  caseId = null,
+  resolutionStatus = null,
+  phase = null,
+  llmPlannerEnabled = MEMORY_CONFIG.contextInjection?.llmPlannerEnabled !== false,
+  maxSections = MEMORY_CONFIG.contextInjection?.maxAuxiliarySections || 2,
+  llmJsonFn = llmJson,
+  isLlmAvailableFn = isLlmAvailable
+} = {}) {
+  const query = typeof contextText === "string" ? contextText.trim() : "";
+  const hasSignals = Boolean(query || caseId || resolutionStatus || phase);
+  if (!hasSignals) {
+    return { sections: [], source: "none", rationale: "no planning signals" };
+  }
+
+  const heuristicPlan = buildHeuristicAuxiliaryPlan({
+    contextText      : query,
+    caseId,
+    resolutionStatus,
+    phase,
+    maxSections
+  });
+
+  if (!llmPlannerEnabled) {
+    return heuristicPlan;
+  }
+
+  try {
+    if (!(await isLlmAvailableFn())) {
+      return heuristicPlan;
+    }
+
+    const candidates = Object.entries(AUXILIARY_SECTION_CATALOG)
+      .map(([name, meta]) => `- ${name}: ${meta.description}`)
+      .join("\n");
+
+    const systemPrompt =
+      "You are a JSON-only planner for auxiliary memory injection. " +
+      "Return valid JSON only. Do not include markdown or explanations outside JSON.";
+
+    const userPrompt = [
+      `Select up to ${maxSections} auxiliary memory sections for the current context.`,
+      "",
+      "Current signals:",
+      `- user_query: ${query || "(empty)"}`,
+      `- case_id: ${caseId || "(none)"}`,
+      `- resolution_status: ${resolutionStatus || "(none)"}`,
+      `- phase: ${phase || "(none)"}`,
+      "",
+      "Candidate sections:",
+      candidates,
+      "",
+      `Heuristic suggestion: ${heuristicPlan.sections.join(", ") || "(none)"}`,
+      "",
+      "Return JSON in this exact shape:",
+      '{"sections":["candidate_name"],"rationale":"short reason"}',
+      "",
+      "Selection rules:",
+      "- Select only sections that materially help the current context.",
+      "- Prefer 0-2 sections; do not select a section just because it exists.",
+      "- If the query is vague or no section clearly helps, return an empty array."
+    ].join("\n");
+
+    const result = await llmJsonFn(userPrompt, {
+      timeoutMs   : 15_000,
+      temperature : 0,
+      systemPrompt
+    });
+
+    const sections = sanitizeSections(result?.sections, maxSections);
+    return {
+      sections,
+      source   : "llm",
+      rationale: typeof result?.rationale === "string" ? result.rationale : null
+    };
+  } catch (err) {
+    logWarn(`[AuxiliarySectionPlanner] LLM planner failed, fallback to heuristic: ${err.message}`);
+    return heuristicPlan;
+  }
+}

--- a/lib/memory/ContextBuilder.js
+++ b/lib/memory/ContextBuilder.js
@@ -238,7 +238,9 @@ export class ContextBuilder {
     for (const f of extras) {
       if (totalAdded >= maxCore) break;
 
-      const typeKey  = f.type || "general";
+      const typeKey  = this.#hardeningEnabled && f.source === "learning_extraction"
+        ? "learning"
+        : (f.type || "general");
       const typeMax  = typeSlots[typeKey] || 5;
       const current  = typeCounters[typeKey] || 0;
       if (current >= typeMax) continue;

--- a/lib/memory/ContextBuilder.js
+++ b/lib/memory/ContextBuilder.js
@@ -89,15 +89,21 @@ export class ContextBuilder {
   #store;
   #index;
   #getPool;
+  #hardeningEnabled;
 
   /**
-   * @param {{ recall: Function, store: object, index: object, getPool?: Function }} deps
+   * @param {{ recall: Function, store: object, index: object, getPool?: Function, hardeningEnabled?: boolean }} deps
+   *
+   * hardeningEnabled: 신규 기능(Closed Learning Loop, is_anchor 필터) 활성화 여부.
+   *   미지정 시 MEMORY_CONFIG.contextInjection.hardening.enabled 값을 사용 (기본 false).
+   *   true → 신규 동작 활성화; false → 명시적 레거시 호환 모드.
    */
-  constructor({ recall, store, index, getPool }) {
-    this.#recall  = recall;
-    this.#store   = store;
-    this.#index   = index;
-    this.#getPool = getPool || getPrimaryPool;
+  constructor({ recall, store, index, getPool, hardeningEnabled }) {
+    this.#recall           = recall;
+    this.#store            = store;
+    this.#index            = index;
+    this.#getPool          = getPool || getPrimaryPool;
+    this.#hardeningEnabled = hardeningEnabled ?? (MEMORY_CONFIG.contextInjection?.hardening?.enabled === true);
   }
 
   /**
@@ -155,6 +161,24 @@ export class ContextBuilder {
         typeFragMap.set("session_reflect", reflectResult.fragments);
         types.push("session_reflect");
       }
+    }
+
+    /** -- Learning 파편 우선 로드 (Closed Learning Loop, hardening.enabled=true 시만 활성) -- */
+    let learningFragments = [];
+    if (this.#hardeningEnabled) {
+      try {
+        learningFragments = await this.#store.searchBySource(
+          "learning_extraction",
+          agentId,
+          keyId,
+          5,
+          workspace
+        );
+        if (learningFragments.length > 0) {
+          typeFragMap.set("learning", learningFragments);
+          types.unshift("learning");
+        }
+      } catch { /* learning 로딩 실패 무시 */ }
     }
 
     const guaranteed = new Map();
@@ -274,16 +298,20 @@ export class ContextBuilder {
       if (pool) {
         const anchorParams    = [];
         let   anchorKeyFilter = "";
+        let   anchorWorkspaceFilter = "";
         if (groupKeyIds != null) {
           anchorParams.push(groupKeyIds);
           anchorKeyFilter = `AND key_id = ANY($${anchorParams.length})`;
         }
+        anchorParams.push(workspace);
+        anchorWorkspaceFilter = `AND ($${anchorParams.length}::text IS NULL OR workspace = $${anchorParams.length} OR workspace IS NULL)`;
         const anchorResult = await pool.query(
-          `SELECT id, content, type, topic, importance
+          `SELECT id, content, type, topic, importance, TRUE AS is_anchor
              FROM agent_memory.fragments
             WHERE is_anchor = TRUE
               AND valid_to IS NULL
               ${anchorKeyFilter}
+              ${anchorWorkspaceFilter}
             ORDER BY importance DESC
             LIMIT 10`,
           anchorParams
@@ -293,15 +321,6 @@ export class ContextBuilder {
     } catch (err) {
       logWarn(`[ContextBuilder] anchor load failed: ${err.message}`);
     }
-
-    /** -- Learning 파편 우선 주입 (Closed Learning Loop) -- */
-    try {
-      const learningFrags = await this.#store.searchBySource("learning_extraction", agentId, keyId, 5);
-      if (learningFrags.length > 0) {
-        typeFragMap.set("learning", learningFrags);
-        types.unshift("learning");
-      }
-    } catch { /* learning 로딩 실패 무시 */ }
 
     /** -- 주입용 텍스트 생성 (Anchor + Core + WM 분리) -- */
     const lines = [];
@@ -315,6 +334,7 @@ export class ContextBuilder {
 
     const coreSections = {};
     for (const f of coreFragments) {
+      if (f.source === "learning_extraction") continue;
       const key = f.type || "general";
       if (!coreSections[key]) coreSections[key] = [];
       coreSections[key].push(f.content);
@@ -328,6 +348,14 @@ export class ContextBuilder {
         for (const c of contents) {
           lines.push(`- ${c}`);
         }
+      }
+    }
+
+    if (this.#hardeningEnabled && learningFragments.length > 0) {
+      lines.push("");
+      lines.push("[LEARNING MEMORY]");
+      for (const f of learningFragments) {
+        lines.push(`- ${f.content}`);
       }
     }
 
@@ -376,17 +404,21 @@ export class ContextBuilder {
     if (params.structured === true) {
       const coreByType = {};
       for (const f of coreFragments) {
+        if (f.source === "learning_extraction") continue;
         const key = f.type || "general";
         if (!coreByType[key]) coreByType[key] = [];
         coreByType[key].push(f);
       }
 
-      const learningFragments = typeFragMap.get("learning") || [];
-
       const contextHint  = buildContextHint(dedupResult);
       const rankWeights  = MEMORY_CONFIG.contextInjection.rankWeights;
-      const anchorFrags  = dedupResult.filter(f => f.type === "anchor");
-      const otherFrags   = dedupResult.filter(f => f.type !== "anchor");
+      // hardening=true: is_anchor 필드 기반(정확). hardening=false: 기존 동작 유지(type==="anchor"는 항상 빈 배열이었음).
+      const anchorFrags  = this.#hardeningEnabled
+        ? dedupResult.filter(f => f.is_anchor === true)
+        : dedupResult.filter(f => f.type === "anchor");
+      const otherFrags   = this.#hardeningEnabled
+        ? dedupResult.filter(f => f.is_anchor !== true)
+        : dedupResult.filter(f => f.type !== "anchor");
       const ranked       = buildRankedInjection(
         anchorFrags, otherFrags,
         params.tokenBudget ?? MEMORY_CONFIG.contextInjection.defaultTokenBudget,

--- a/lib/memory/ContextBuilder.js
+++ b/lib/memory/ContextBuilder.js
@@ -336,7 +336,7 @@ export class ContextBuilder {
 
     const coreSections = {};
     for (const f of coreFragments) {
-      if (f.source === "learning_extraction") continue;
+      if (this.#hardeningEnabled && f.source === "learning_extraction") continue;
       const key = f.type || "general";
       if (!coreSections[key]) coreSections[key] = [];
       coreSections[key].push(f.content);
@@ -406,7 +406,7 @@ export class ContextBuilder {
     if (params.structured === true) {
       const coreByType = {};
       for (const f of coreFragments) {
-        if (f.source === "learning_extraction") continue;
+        if (this.#hardeningEnabled && f.source === "learning_extraction") continue;
         const key = f.type || "general";
         if (!coreByType[key]) coreByType[key] = [];
         coreByType[key].push(f);

--- a/lib/memory/ContextBuilder.js
+++ b/lib/memory/ContextBuilder.js
@@ -342,6 +342,10 @@ export class ContextBuilder {
       coreSections[key].push(f.content);
     }
 
+    const accountedLearningFragments = this.#hardeningEnabled
+      ? coreFragments.filter(f => f.source === "learning_extraction")
+      : [];
+
     if (Object.keys(coreSections).length > 0) {
       if (lines.length > 0) lines.push("");
       lines.push("[CORE MEMORY]");
@@ -353,10 +357,10 @@ export class ContextBuilder {
       }
     }
 
-    if (this.#hardeningEnabled && learningFragments.length > 0) {
+    if (this.#hardeningEnabled && accountedLearningFragments.length > 0) {
       lines.push("");
       lines.push("[LEARNING MEMORY]");
-      for (const f of learningFragments) {
+      for (const f of accountedLearningFragments) {
         lines.push(`- ${f.content}`);
       }
     }
@@ -447,7 +451,7 @@ export class ContextBuilder {
           permanent: anchorFragments
         },
         learning        : {
-          recent: learningFragments
+          recent: accountedLearningFragments
         },
         totalTokens     : anchorTokens + coreTokens + wmTokens,
         count           : dedupResult.length,

--- a/lib/memory/ContextBuilder.js
+++ b/lib/memory/ContextBuilder.js
@@ -95,7 +95,7 @@ export class ContextBuilder {
    * @param {{ recall: Function, store: object, index: object, getPool?: Function, hardeningEnabled?: boolean }} deps
    *
    * hardeningEnabled: 신규 기능(Closed Learning Loop, is_anchor 필터) 활성화 여부.
-   *   미지정 시 MEMORY_CONFIG.contextInjection.hardening.enabled 값을 사용 (기본 false).
+   *   미지정 시 MEMORY_CONFIG.contextInjection.hardeningEnabled 값을 사용 (기본 false).
    *   true → 신규 동작 활성화; false → 명시적 레거시 호환 모드.
    */
   constructor({ recall, store, index, getPool, hardeningEnabled }) {
@@ -103,7 +103,7 @@ export class ContextBuilder {
     this.#store            = store;
     this.#index            = index;
     this.#getPool          = getPool || getPrimaryPool;
-    this.#hardeningEnabled = hardeningEnabled ?? (MEMORY_CONFIG.contextInjection?.hardening?.enabled === true);
+    this.#hardeningEnabled = hardeningEnabled ?? (MEMORY_CONFIG.contextInjection?.hardeningEnabled === true);
   }
 
   /**
@@ -163,7 +163,7 @@ export class ContextBuilder {
       }
     }
 
-    /** -- Learning 파편 우선 로드 (Closed Learning Loop, hardening.enabled=true 시만 활성) -- */
+    /** -- Learning 파편 우선 로드 (Closed Learning Loop, hardeningEnabled=true 시만 활성) -- */
     let learningFragments = [];
     if (this.#hardeningEnabled) {
       try {

--- a/lib/memory/ContextBuilder.js
+++ b/lib/memory/ContextBuilder.js
@@ -11,6 +11,7 @@
 import { MEMORY_CONFIG }   from "../../config/memory.js";
 import { getPrimaryPool }  from "../tools/db.js";
 import { logWarn }         from "../logger.js";
+import { AUXILIARY_SECTION_CATALOG, planAuxiliarySections } from "./AuxiliarySectionPlanner.js";
 
 /**
  * context 응답에 포함할 힌트를 생성한다.
@@ -84,26 +85,253 @@ function buildRankedInjection(anchorFragments, otherFragments, tokenBudget, weig
   return { items, totalTokens: usedTokens };
 }
 
+function capFragmentsToBudget(fragments, budgetChars) {
+  const capped = [];
+  let used = 0;
+
+  for (const frag of fragments) {
+    const content = frag.content || "";
+    const cost = content.length;
+
+    if (used + cost <= budgetChars) {
+      capped.push(frag);
+      used += cost;
+      continue;
+    }
+
+    const remaining = budgetChars - used;
+    if (remaining > 80) {
+      capped.push({
+        ...frag,
+        content: content.substring(0, remaining - 3) + "..."
+      });
+    }
+    break;
+  }
+
+  return capped;
+}
+
+function buildCaseSummaryLine(item) {
+  const parts = [`${item.case_id} [${item.resolution_status || "open"}]`];
+  if (item.goal) parts.push(`goal: ${item.goal}`);
+  if (item.outcome) parts.push(`outcome: ${item.outcome}`);
+  if (!item.goal && !item.outcome && item.events?.[0]?.summary) {
+    parts.push(`hint: ${item.events[0].summary}`);
+  }
+  return `- ${parts.join(" | ")}`;
+}
+
+function buildAuxiliarySectionLines(section) {
+  const lines = [];
+  if (Array.isArray(section.fragments) && section.fragments.length > 0) {
+    for (const frag of section.fragments) {
+      lines.push(`- ${frag.content}`);
+    }
+  } else if (Array.isArray(section.cases) && section.cases.length > 0) {
+    for (const item of section.cases) {
+      lines.push(buildCaseSummaryLine(item));
+    }
+  }
+  if (lines.length === 0) return [];
+  return [`[${section.title}]`, ...lines];
+}
+
 export class ContextBuilder {
   #recall;
   #store;
   #index;
   #getPool;
   #hardeningEnabled;
+  #auxiliaryPlanner;
 
   /**
-   * @param {{ recall: Function, store: object, index: object, getPool?: Function, hardeningEnabled?: boolean }} deps
+   * @param {{ recall: Function, store: object, index: object, getPool?: Function, hardeningEnabled?: boolean, auxiliaryPlanner?: Function }} deps
    *
    * hardeningEnabled: 신규 기능(Closed Learning Loop, is_anchor 필터) 활성화 여부.
    *   미지정 시 MEMORY_CONFIG.contextInjection.hardeningEnabled 값을 사용 (기본 false).
    *   true → 신규 동작 활성화; false → 명시적 레거시 호환 모드.
    */
-  constructor({ recall, store, index, getPool, hardeningEnabled }) {
+  constructor({ recall, store, index, getPool, hardeningEnabled, auxiliaryPlanner }) {
     this.#recall           = recall;
     this.#store            = store;
     this.#index            = index;
     this.#getPool          = getPool || getPrimaryPool;
     this.#hardeningEnabled = hardeningEnabled ?? (MEMORY_CONFIG.contextInjection?.hardeningEnabled === true);
+    this.#auxiliaryPlanner = auxiliaryPlanner || planAuxiliarySections;
+  }
+
+  async #loadAuxiliarySection(sectionKey, params) {
+    const agentId            = params.agentId || "default";
+    const keyId              = params._keyId ?? null;
+    const groupKeyIds        = params._groupKeyIds ?? (keyId ? [keyId] : null);
+    const workspace          = params.workspace ?? params._defaultWorkspace ?? null;
+    const auxiliaryBudget    = MEMORY_CONFIG.contextInjection?.auxiliaryTokenBudget || 250;
+    const auxiliaryCharBudget = auxiliaryBudget * 4;
+    const query              = typeof params.contextText === "string" ? params.contextText.trim() : "";
+    const baseRecallParams   = {
+      tokenBudget  : auxiliaryBudget,
+      minImportance: 0.3,
+      excludeSeen  : false,
+      agentId,
+      _keyId       : keyId,
+      _groupKeyIds : groupKeyIds,
+      workspace,
+      ...(query ? { text: query, contextText: query } : {}),
+      ...(params.caseId ? { caseId: params.caseId } : {}),
+      ...(params.resolutionStatus ? { resolutionStatus: params.resolutionStatus } : {}),
+      ...(params.phase ? { phase: params.phase } : {})
+    };
+
+    switch (sectionKey) {
+      case "learning_memory": {
+        let fragments = [];
+
+        if (query) {
+          const result = await this.#recall({
+            ...baseRecallParams,
+            includeLinks: false,
+            source      : "learning_extraction"
+          });
+          fragments = result.fragments || [];
+        }
+
+        if (fragments.length === 0) {
+          fragments = await this.#store.searchBySource(
+            "learning_extraction",
+            agentId,
+            keyId,
+            5,
+            workspace
+          );
+          if (params.caseId) {
+            fragments = fragments.filter(f => f.case_id === params.caseId);
+          }
+          if (params.resolutionStatus) {
+            fragments = fragments.filter(f => f.resolution_status === params.resolutionStatus);
+          }
+          if (params.phase) {
+            fragments = fragments.filter(f => f.phase === params.phase);
+          }
+        }
+
+        fragments = capFragmentsToBudget(fragments, auxiliaryCharBudget);
+        if (fragments.length === 0) return null;
+        return {
+          key      : sectionKey,
+          title    : AUXILIARY_SECTION_CATALOG[sectionKey].title,
+          fragments
+        };
+      }
+
+      case "error_playbook": {
+        const result = await this.#recall({
+          ...baseRecallParams,
+          type        : "error",
+          depth       : "tool-level",
+          includeLinks: true
+        });
+        const fragments = capFragmentsToBudget(result.fragments || [], auxiliaryCharBudget);
+        if (fragments.length === 0) return null;
+        return {
+          key      : sectionKey,
+          title    : AUXILIARY_SECTION_CATALOG[sectionKey].title,
+          fragments
+        };
+      }
+
+      case "decision_memory": {
+        const result = await this.#recall({
+          ...baseRecallParams,
+          type        : "decision",
+          depth       : "high-level",
+          includeLinks: false
+        });
+        const fragments = capFragmentsToBudget(result.fragments || [], auxiliaryCharBudget);
+        if (fragments.length === 0) return null;
+        return {
+          key      : sectionKey,
+          title    : AUXILIARY_SECTION_CATALOG[sectionKey].title,
+          fragments
+        };
+      }
+
+      case "open_questions_memory": {
+        const result = await this.#recall({
+          ...baseRecallParams,
+          topic           : "session_reflect",
+          type            : "fact",
+          resolutionStatus: "open",
+          includeLinks    : false
+        });
+        const fragments = capFragmentsToBudget(result.fragments || [], auxiliaryCharBudget);
+        if (fragments.length === 0) return null;
+        return {
+          key      : sectionKey,
+          title    : AUXILIARY_SECTION_CATALOG[sectionKey].title,
+          fragments
+        };
+      }
+
+      case "case_memory": {
+        const result = await this.#recall({
+          ...baseRecallParams,
+          includeLinks: false,
+          caseMode    : true,
+          maxCases    : MEMORY_CONFIG.contextInjection?.caseMemoryMaxCases || 2
+        });
+        const cases     = Array.isArray(result.cases) ? result.cases.slice(0, MEMORY_CONFIG.contextInjection?.caseMemoryMaxCases || 2) : [];
+        const fragments = capFragmentsToBudget(result.fragments || [], auxiliaryCharBudget);
+        if (cases.length === 0) return null;
+        return {
+          key      : sectionKey,
+          title    : AUXILIARY_SECTION_CATALOG[sectionKey].title,
+          cases,
+          fragments
+        };
+      }
+
+      default:
+        return null;
+    }
+  }
+
+  async #buildAuxiliarySections(params, existingIds) {
+    if (!this.#hardeningEnabled) return [];
+
+    const plan = await this.#auxiliaryPlanner({
+      contextText      : params.contextText,
+      caseId           : params.caseId,
+      resolutionStatus : params.resolutionStatus,
+      phase            : params.phase,
+      llmPlannerEnabled: MEMORY_CONFIG.contextInjection?.llmPlannerEnabled !== false,
+      maxSections      : MEMORY_CONFIG.contextInjection?.maxAuxiliarySections || 2
+    });
+
+    const sections = [];
+    for (const sectionKey of plan.sections || []) {
+      try {
+        const section = await this.#loadAuxiliarySection(sectionKey, params);
+        if (!section) continue;
+
+        if (Array.isArray(section.fragments)) {
+          section.fragments = section.fragments.filter((frag) => {
+            if (!frag?.id || existingIds.has(frag.id)) return false;
+            existingIds.add(frag.id);
+            return true;
+          });
+        }
+
+        if ((section.fragments?.length || 0) === 0 && (section.cases?.length || 0) === 0) {
+          continue;
+        }
+        sections.push(section);
+      } catch (err) {
+        logWarn(`[ContextBuilder] auxiliary section load failed (${sectionKey}): ${err.message}`);
+      }
+    }
+
+    return sections;
   }
 
   /**
@@ -114,6 +342,10 @@ export class ContextBuilder {
    *   - sessionId   {string} 세션 ID (선택)
    *   - tokenBudget {number} 기본 2000
    *   - types       {string[]} 로드할 유형 목록 (기본: preference, error, procedure)
+   *   - contextText {string} 현재 user 질의/대화 맥락. hardening=true면 learning_extraction query-aware attach에 사용
+   *   - caseId      {string} 특정 케이스 컨텍스트 필터
+   *   - resolutionStatus {string} open|resolved|abandoned 필터
+   *   - phase       {string} planning|debugging|verification 등 단계 필터
    *   - structured  {boolean} 계층적 트리 구조 반환 여부
    * @returns {Object} { fragments, totalTokens, injectionText, coreTokens, wmTokens, wmCount }
    */
@@ -163,22 +395,10 @@ export class ContextBuilder {
       }
     }
 
-    /** -- Learning 파편 우선 로드 (Closed Learning Loop, hardeningEnabled=true 시만 활성) -- */
-    let learningFragments = [];
     if (this.#hardeningEnabled) {
-      try {
-        learningFragments = await this.#store.searchBySource(
-          "learning_extraction",
-          agentId,
-          keyId,
-          5,
-          workspace
-        );
-        if (learningFragments.length > 0) {
-          typeFragMap.set("learning", learningFragments);
-          types.unshift("learning");
-        }
-      } catch { /* learning 로딩 실패 무시 */ }
+      for (const [type, frags] of typeFragMap.entries()) {
+        typeFragMap.set(type, (frags || []).filter(f => f.source !== "learning_extraction"));
+      }
     }
 
     const guaranteed = new Map();
@@ -238,9 +458,7 @@ export class ContextBuilder {
     for (const f of extras) {
       if (totalAdded >= maxCore) break;
 
-      const typeKey  = this.#hardeningEnabled && f.source === "learning_extraction"
-        ? "learning"
-        : (f.type || "general");
+      const typeKey  = f.type || "general";
       const typeMax  = typeSlots[typeKey] || 5;
       const current  = typeCounters[typeKey] || 0;
       if (current >= typeMax) continue;
@@ -324,6 +542,14 @@ export class ContextBuilder {
       logWarn(`[ContextBuilder] anchor load failed: ${err.message}`);
     }
 
+    const existingIds = new Set(
+      [...anchorFragments, ...coreFragments, ...wmFragments]
+        .map(f => f.id)
+        .filter(Boolean)
+    );
+    const auxiliarySections = await this.#buildAuxiliarySections(params, existingIds);
+    const auxiliaryFragments = auxiliarySections.flatMap(section => section.fragments || []);
+
     /** -- 주입용 텍스트 생성 (Anchor + Core + WM 분리) -- */
     const lines = [];
 
@@ -336,15 +562,10 @@ export class ContextBuilder {
 
     const coreSections = {};
     for (const f of coreFragments) {
-      if (this.#hardeningEnabled && f.source === "learning_extraction") continue;
       const key = f.type || "general";
       if (!coreSections[key]) coreSections[key] = [];
       coreSections[key].push(f.content);
     }
-
-    const accountedLearningFragments = this.#hardeningEnabled
-      ? coreFragments.filter(f => f.source === "learning_extraction")
-      : [];
 
     if (Object.keys(coreSections).length > 0) {
       if (lines.length > 0) lines.push("");
@@ -357,12 +578,11 @@ export class ContextBuilder {
       }
     }
 
-    if (this.#hardeningEnabled && accountedLearningFragments.length > 0) {
-      lines.push("");
-      lines.push("[LEARNING MEMORY]");
-      for (const f of accountedLearningFragments) {
-        lines.push(`- ${f.content}`);
-      }
+    for (const section of auxiliarySections) {
+      const sectionLines = buildAuxiliarySectionLines(section);
+      if (sectionLines.length === 0) continue;
+      if (lines.length > 0) lines.push("");
+      lines.push(...sectionLines);
     }
 
     if (wmFragments.length > 0) {
@@ -386,12 +606,14 @@ export class ContextBuilder {
     } catch { /* 무시 */ }
 
     const anchorChars  = anchorFragments.reduce((s, f) => s + (f.content || "").length, 0);
+    const auxiliaryChars = auxiliaryFragments.reduce((s, f) => s + (f.content || "").length, 0);
     const coreTokens   = Math.ceil(usedChars / 4);
+    const auxiliaryTokens = Math.ceil(auxiliaryChars / 4);
     const wmTokens     = Math.ceil(wmChars / 4);
     const anchorTokens = Math.ceil(anchorChars / 4);
 
     /** -- 중복 제거: 동일 ID 파편은 첫 등장만 유지 -- */
-    const allFragments = [...anchorFragments, ...coreFragments, ...wmFragments];
+    const allFragments = [...anchorFragments, ...coreFragments, ...auxiliaryFragments, ...wmFragments];
     const dedupSeen    = new Set();
     const dedupResult  = [];
     for (const f of allFragments) {
@@ -410,11 +632,15 @@ export class ContextBuilder {
     if (params.structured === true) {
       const coreByType = {};
       for (const f of coreFragments) {
-        if (this.#hardeningEnabled && f.source === "learning_extraction") continue;
         const key = f.type || "general";
         if (!coreByType[key]) coreByType[key] = [];
         coreByType[key].push(f);
       }
+      const learningFragments = auxiliarySections.find(section => section.key === "learning_memory")?.fragments || [];
+      const errorPlaybook = auxiliarySections.find(section => section.key === "error_playbook")?.fragments || [];
+      const decisionMemory = auxiliarySections.find(section => section.key === "decision_memory")?.fragments || [];
+      const openQuestionsMemory = auxiliarySections.find(section => section.key === "open_questions_memory")?.fragments || [];
+      const caseMemory = auxiliarySections.find(section => section.key === "case_memory")?.cases || [];
 
       const contextHint  = buildContextHint(dedupResult);
       const rankWeights  = MEMORY_CONFIG.contextInjection.rankWeights;
@@ -451,12 +677,19 @@ export class ContextBuilder {
           permanent: anchorFragments
         },
         learning        : {
-          recent: accountedLearningFragments
+          recent: learningFragments
         },
-        totalTokens     : anchorTokens + coreTokens + wmTokens,
+        auxiliary       : {
+          errorPlaybook,
+          decisionMemory,
+          openQuestionsMemory,
+          caseMemory
+        },
+        totalTokens     : anchorTokens + coreTokens + auxiliaryTokens + wmTokens,
         count           : dedupResult.length,
         anchorTokens,
         coreTokens,
+        auxiliaryTokens,
         wmTokens,
         wmCount         : wmFragments.length,
         anchorCount     : anchorFragments.length,
@@ -468,10 +701,11 @@ export class ContextBuilder {
     const contextHint = buildContextHint(dedupResult);
     return {
       fragments    : dedupResult,
-      totalTokens  : anchorTokens + coreTokens + wmTokens,
+      totalTokens  : anchorTokens + coreTokens + auxiliaryTokens + wmTokens,
       count        : dedupResult.length,
       anchorTokens,
       coreTokens,
+      auxiliaryTokens,
       wmTokens,
       wmCount      : wmFragments.length,
       anchorCount  : anchorFragments.length,

--- a/lib/memory/FragmentReader.js
+++ b/lib/memory/FragmentReader.js
@@ -142,6 +142,11 @@ export class FragmentReader {
       params.push(options.minImportance);
       paramIdx++;
     }
+    if (options.source) {
+      conditions.push(`source = $${paramIdx}`);
+      params.push(options.source);
+      paramIdx++;
+    }
     if (options.isAnchor !== undefined) {
       conditions.push(`is_anchor = $${paramIdx}`);
       params.push(options.isAnchor);
@@ -202,6 +207,7 @@ export class FragmentReader {
 
     const result = await queryWithAgentVector(agentId,
       `SELECT f.id, f.content, f.topic, f.keywords, f.type, f.importance, f.utility_score,
+                    f.source,
                     f.linked_to, f.access_count, f.created_at, f.verified_at, f.is_anchor, f.valid_to,
                     f.key_id, f.context_summary, f.session_id, f.workspace,
                     f.case_id, f.goal, f.outcome, f.phase, f.resolution_status, f.assertion_status,
@@ -234,6 +240,11 @@ export class FragmentReader {
     if (options.minImportance) {
       conditions.push(`importance >= $${paramIdx}`);
       params.push(options.minImportance);
+      paramIdx++;
+    }
+    if (options.source) {
+      conditions.push(`source = $${paramIdx}`);
+      params.push(options.source);
       paramIdx++;
     }
     if (options.keyId) {
@@ -286,6 +297,7 @@ export class FragmentReader {
 
     const result = await queryWithAgentVector(agentId,
       `SELECT f.id, f.content, f.topic, f.keywords, f.type, f.importance, f.utility_score,
+              f.source,
               f.linked_to, f.access_count, f.created_at, f.verified_at, f.is_anchor, f.valid_to,
               f.key_id, f.context_summary, f.session_id, f.workspace,
               f.case_id, f.goal, f.outcome, f.phase, f.resolution_status, f.assertion_status
@@ -309,7 +321,7 @@ export class FragmentReader {
    * @param {string|null} keyId - null: 마스터(전체), string: 해당 API 키 소유만
    * @param {boolean}     includeSuperseded
    */
-  async searchBySemantic(queryEmbedding, limit = 10, minSimilarity = 0.3, agentId = "default", keyId = null, includeSuperseded = false, timeRange = null, workspace = null) {
+  async searchBySemantic(queryEmbedding, limit = 10, minSimilarity = 0.3, agentId = "default", keyId = null, includeSuperseded = false, timeRange = null, workspace = null, filters = {}) {
     const vecStr     = vectorToSql(queryEmbedding);
     const conditions = [
       "f.embedding IS NOT NULL",
@@ -332,6 +344,18 @@ export class FragmentReader {
       paramIdx++;
     }
 
+    if (filters.source) {
+      conditions.push(`f.source = $${paramIdx}`);
+      params.push(filters.source);
+      paramIdx++;
+    }
+
+    if (filters.isAnchor !== undefined) {
+      conditions.push(`f.is_anchor = $${paramIdx}`);
+      params.push(filters.isAnchor);
+      paramIdx++;
+    }
+
     /** superseded 파편 필터: includeSuperseded가 아니면 valid_to IS NULL만 조회 */
     if (!includeSuperseded) {
       conditions.push("f.valid_to IS NULL");
@@ -351,8 +375,25 @@ export class FragmentReader {
       }
     }
 
+    if (filters.caseId) {
+      conditions.push(`f.case_id = $${paramIdx}`);
+      params.push(filters.caseId);
+      paramIdx++;
+    }
+    if (filters.resolutionStatus) {
+      conditions.push(`f.resolution_status = $${paramIdx}`);
+      params.push(filters.resolutionStatus);
+      paramIdx++;
+    }
+    if (filters.phase) {
+      conditions.push(`f.phase = $${paramIdx}`);
+      params.push(filters.phase);
+      paramIdx++;
+    }
+
     const result = await queryWithAgentVector(agentId,
       `SELECT f.id, f.content, f.topic, f.keywords, f.type, f.importance, f.utility_score,
+                    f.source,
                     f.linked_to, f.access_count, f.created_at, f.verified_at, f.is_anchor, f.valid_to,
                     f.key_id, f.context_summary, f.session_id, f.workspace,
                     f.case_id, f.goal, f.outcome, f.phase, f.resolution_status, f.assertion_status,
@@ -409,6 +450,12 @@ export class FragmentReader {
       paramIdx++;
     }
 
+    if (options.source) {
+      conditions.push(`source = $${paramIdx}`);
+      params.push(options.source);
+      paramIdx++;
+    }
+
     /** Narrative Reconstruction 필터 (case_id, resolution_status, phase) */
     if (options.caseId) {
       conditions.push(`case_id = $${paramIdx}`);
@@ -431,6 +478,7 @@ export class FragmentReader {
 
     const result = await queryWithAgentVector(agentId,
       `SELECT id, content, topic, keywords, type, importance, utility_score,
+              source,
               linked_to, access_count, created_at, verified_at, is_anchor, valid_to,
               context_summary, session_id, workspace,
               case_id, goal, outcome, phase, resolution_status, assertion_status

--- a/lib/memory/FragmentSearch.js
+++ b/lib/memory/FragmentSearch.js
@@ -48,6 +48,7 @@ export class FragmentSearch {
      *   - keywords    {string[]}    키워드 목록
      *   - topic       {string}      토픽
      *   - type        {string}      파편 유형
+     *   - source      {string}      source 필터 (예: learning_extraction)
      *   - text        {string}      자연어 쿼리 (시맨틱 검색용)
      *   - tokenBudget {number}      최대 토큰 (기본 1000)
      *   - keyId       {string|null} API 키 ID (null: 마스터, string: 격리 조회)
@@ -183,6 +184,7 @@ export class FragmentSearch {
       timeRange         : parseTimeRange(query.timeRange),
       fragmentCount     : query.fragmentCount || 0,
       includeSuperseded : query.includeSuperseded || false,
+      source            : query.source || undefined,
       caseId            : query.caseId || undefined,
       resolutionStatus  : query.resolutionStatus || undefined,
       phase             : query.phase || undefined
@@ -337,6 +339,10 @@ export class FragmentSearch {
       combined = combined.filter(f => f.workspace === workspace || f.workspace == null);
     }
 
+    if (sq.source) {
+      combined = combined.filter(f => f.source === sq.source);
+    }
+
     /** Narrative Reconstruction 후처리 필터: L1/L3/Graph 경로 보완 */
     if (sq.caseId) {
       combined = combined.filter(f => f.case_id === sq.caseId);
@@ -367,6 +373,7 @@ export class FragmentSearch {
       sq.timeRange.from, sq.timeRange.to,
       {
         agentId: sq.agentId, keyId: sq.keyId, workspace: sq.workspace, limit: 30,
+        ...(sq.source ? { source: sq.source } : {}),
         ...(sq.caseId           ? { caseId: sq.caseId } : {}),
         ...(sq.resolutionStatus ? { resolutionStatus: sq.resolutionStatus } : {}),
         ...(sq.phase            ? { phase: sq.phase } : {})
@@ -449,6 +456,7 @@ export class FragmentSearch {
       keyId             : keyId,
       workspace         : query.workspace ?? null,
       includeSuperseded : query.includeSuperseded || false,
+      ...(query.source ? { source: query.source } : {}),
       ...(query.isAnchor !== undefined ? { isAnchor: query.isAnchor } : {}),
       ...(timeRange ? { timeRange } : {}),
       ...(query.caseId           ? { caseId: query.caseId } : {}),
@@ -467,6 +475,24 @@ export class FragmentSearch {
       results = await this.store.searchByTopic(query.topic, options);
     }
 
+    /** source-only 또는 source 보강 fallback */
+    if (results.length === 0 && query.source) {
+      results = await this.store.searchBySource(
+        query.source,
+        agentId,
+        keyId,
+        options.limit,
+        query.workspace ?? null
+      );
+
+      if (options.type) {
+        results = results.filter(f => f.type === options.type);
+      }
+      if (options.minImportance) {
+        results = results.filter(f => (f.importance || 0) >= options.minImportance);
+      }
+    }
+
     /** 추가 ID 기반 조회 (L1에서 찾은 것 중 캐시 미스분) */
     if (excludeIds.length > 0) {
       const cachedResultIds = new Set(results.map(r => r.id));
@@ -477,6 +503,9 @@ export class FragmentSearch {
         /** workspace 필터: getByIds는 workspace 미지원이므로 여기서 후처리 적용 */
         if (options.workspace) {
           fetched = fetched.filter(f => f.workspace === options.workspace || f.workspace == null);
+        }
+        if (options.source) {
+          fetched = fetched.filter(f => f.source === options.source);
         }
         results.push(...fetched);
       }
@@ -507,7 +536,23 @@ export class FragmentSearch {
       const { minSimilarity: cfgSim, limit } = MEMORY_CONFIG.semanticSearch || {};
       const adaptedSim    = await (query._adaptedSimPromise ?? Promise.resolve(null));
       const minSimilarity = adaptedSim ?? cfgSim ?? 0.35;
-      const results = await this.store.searchBySemantic(vec, limit ?? 10, minSimilarity, agentId, keyId, query.includeSuperseded || false, timeRange, query.workspace ?? null);
+      const results = await this.store.searchBySemantic(
+        vec,
+        limit ?? 10,
+        minSimilarity,
+        agentId,
+        keyId,
+        query.includeSuperseded || false,
+        timeRange,
+        query.workspace ?? null,
+        {
+          ...(query.source ? { source: query.source } : {}),
+          ...(query.isAnchor !== undefined ? { isAnchor: query.isAnchor } : {}),
+          ...(query.caseId ? { caseId: query.caseId } : {}),
+          ...(query.resolutionStatus ? { resolutionStatus: query.resolutionStatus } : {}),
+          ...(query.phase ? { phase: query.phase } : {})
+        }
+      );
 
       /** 어시스턴트 쿼리일 때 "Assistant:" 포함 파편에 importance 부스트 */
       if (isAsstQ) {

--- a/lib/memory/FragmentStore.js
+++ b/lib/memory/FragmentStore.js
@@ -28,12 +28,12 @@ export class FragmentStore {
   getHistory(fragmentId, agentId, keyId, groupKeyIds)                 { return this.reader.getHistory(fragmentId, agentId, keyId, groupKeyIds); }
   searchByKeywords(keywords, options)                                  { return this.reader.searchByKeywords(keywords, options); }
   searchByTopic(topic, options)                                        { return this.reader.searchByTopic(topic, options); }
-  searchBySemantic(queryEmbedding, limit, minSimilarity, agentId, keyId, includeSuperseded, timeRange, workspace) {
-    return this.reader.searchBySemantic(queryEmbedding, limit, minSimilarity, agentId, keyId, includeSuperseded, timeRange, workspace);
+  searchBySemantic(queryEmbedding, limit, minSimilarity, agentId, keyId, includeSuperseded, timeRange, workspace, filters = {}) {
+    return this.reader.searchBySemantic(queryEmbedding, limit, minSimilarity, agentId, keyId, includeSuperseded, timeRange, workspace, filters);
   }
   searchByTimeRange(from, to, options)                                  { return this.reader.searchByTimeRange(from, to, options); }
   searchAsOf(asOf, agentId, opts, keyId)                               { return this.reader.searchAsOf(asOf, agentId, opts, keyId); }
-  searchBySource(source, agentId, keyId, limit)                        { return this.reader.searchBySource(source, agentId, keyId, limit); }
+  searchBySource(source, agentId, keyId, limit, workspace = null)      { return this.reader.searchBySource(source, agentId, keyId, limit, workspace); }
   findCaseIdBySessionTopic(sessionId, topic, keyId)                    { return this.reader.findCaseIdBySessionTopic(sessionId, topic, keyId); }
   findErrorFragmentsBySessionTopic(sessionId, topic, keyId)            { return this.reader.findErrorFragmentsBySessionTopic(sessionId, topic, keyId); }
 

--- a/lib/memory/MemoryManager.js
+++ b/lib/memory/MemoryManager.js
@@ -454,6 +454,7 @@ export class MemoryManager {
       keyId: groupKeyIds,                     // API 키 격리 필터 (그룹 배열)
       workspace,                              // 워크스페이스 필터
       sessionId: params.sessionId || null,    // search_events.session_id 전파
+      ...(params.source ? { source: params.source } : {}),
       ...(params.isAnchor !== undefined ? { isAnchor: params.isAnchor } : {}),
       ...(params.caseId            ? { caseId: params.caseId } : {}),
       ...(params.resolutionStatus  ? { resolutionStatus: params.resolutionStatus } : {}),

--- a/lib/tools/memory-schemas.js
+++ b/lib/tools/memory-schemas.js
@@ -279,6 +279,10 @@ export const recallDefinition = {
         description: "워크스페이스 필터. 지정 시 해당 workspace 파편 + 전역(NULL) 파편만 반환. " +
                      "미지정 시 키의 default_workspace 적용."
       },
+      source: {
+        type       : "string",
+        description: "source 필터. 특정 생성 경로의 파편만 좁혀서 검색할 때 사용 (예: 'learning_extraction')."
+      },
       contextText: {
         type       : "string",
         description: "현재 대화 맥락 텍스트. 관련 파편을 선제적으로 활성화한다 (Spreading Activation)."
@@ -550,6 +554,8 @@ export const contextDefinition = {
   description: "Core Memory + Working Memory + session_reflect를 분리 로드한다. " +
                  "세션 시작 시 preference, error, procedure, decision 파편을 주입하여 맥락 유지. " +
                  "직전 세션의 reflect 파편(session_reflect 토픽)도 자동 포함. " +
+                 "hardeningEnabled=true 환경에서는 contextText와 추가 signal(caseId, resolutionStatus, phase)을 바탕으로 " +
+                 "LLM planner가 LEARNING/ERROR/DECISION/OPEN QUESTIONS/CASE MEMORY 같은 보조 섹션을 조건부로 붙일 수 있다. " +
                  "sessionId 전달 시 해당 세션의 워킹 메모리도 함께 반환. " +
                  "structured=true 시 계층적 트리 구조로 반환.",
   inputSchema: {
@@ -576,6 +582,23 @@ export const contextDefinition = {
         type       : "string",
         description: "워크스페이스 필터. 지정 시 해당 workspace 파편 + 전역(NULL) 파편만 반환. " +
                      "미지정 시 키의 default_workspace 적용."
+      },
+      contextText: {
+        type       : "string",
+        description: "현재 user 질의/대화 맥락. hardeningEnabled=true면 LLM planner와 query-aware auxiliary section attach에 사용."
+      },
+      caseId: {
+        type       : "string",
+        description: "특정 케이스/작업 ID. learning 보조 주입과 core recall 모두 같은 케이스로 좁힐 때 사용."
+      },
+      resolutionStatus: {
+        type       : "string",
+        enum       : ["open", "resolved", "abandoned"],
+        description: "해결 상태 필터. learning 보조 주입 시에도 함께 적용된다."
+      },
+      phase: {
+        type       : "string",
+        description: "작업 단계 필터 (예: planning, debugging, verification, completed)."
       },
       structured: {
         type       : "boolean",

--- a/scripts/bootstrap-memento-mcp-source.sh
+++ b/scripts/bootstrap-memento-mcp-source.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SOURCE_DIR_DEFAULT="$REPO_ROOT"
+ORIGIN_URL_DEFAULT="https://github.com/kunkunGames/memento-mcp.git"
+UPSTREAM_URL_DEFAULT="https://github.com/JinHo-von-Choi/memento-mcp.git"
+
+SOURCE_DIR="$SOURCE_DIR_DEFAULT"
+ORIGIN_URL="$ORIGIN_URL_DEFAULT"
+UPSTREAM_URL="$UPSTREAM_URL_DEFAULT"
+PULL_MAIN=1
+
+usage() {
+  cat <<'EOF'
+Usage: bootstrap-memento-mcp-source.sh [options]
+
+Options:
+  --source-dir PATH     Canonical clone path
+  --origin-url URL      Fork remote URL
+  --upstream-url URL    Upstream remote URL
+  --skip-pull           Do not pull origin/main after bootstrap
+  --help                Show this help
+EOF
+}
+
+log() {
+  printf '[bootstrap-memento-mcp-source] %s\n' "$*"
+}
+
+die() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-dir)
+      SOURCE_DIR="${2:?missing value for --source-dir}"
+      shift 2
+      ;;
+    --origin-url)
+      ORIGIN_URL="${2:?missing value for --origin-url}"
+      shift 2
+      ;;
+    --upstream-url)
+      UPSTREAM_URL="${2:?missing value for --upstream-url}"
+      shift 2
+      ;;
+    --skip-pull)
+      PULL_MAIN=0
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd git
+
+if [[ ! -d "$SOURCE_DIR/.git" ]]; then
+  mkdir -p "$(dirname "$SOURCE_DIR")"
+  log "Cloning fork into $SOURCE_DIR"
+  git clone "$ORIGIN_URL" "$SOURCE_DIR"
+else
+  log "Source clone already exists: $SOURCE_DIR"
+fi
+
+git -C "$SOURCE_DIR" remote set-url origin "$ORIGIN_URL"
+if git -C "$SOURCE_DIR" remote get-url upstream >/dev/null 2>&1; then
+  git -C "$SOURCE_DIR" remote set-url upstream "$UPSTREAM_URL"
+else
+  git -C "$SOURCE_DIR" remote add upstream "$UPSTREAM_URL"
+fi
+
+if [[ "$PULL_MAIN" -eq 1 ]]; then
+  current_branch="$(git -C "$SOURCE_DIR" branch --show-current)"
+  dirty_count="$(git -C "$SOURCE_DIR" status --porcelain | wc -l | tr -d ' ')"
+  if [[ "$current_branch" == "main" && "$dirty_count" == "0" ]]; then
+    log "Pulling origin/main"
+    git -C "$SOURCE_DIR" pull --ff-only origin main
+  else
+    log "Skipping pull because branch=$current_branch dirty_count=$dirty_count"
+  fi
+fi
+
+log "Remotes:"
+git -C "$SOURCE_DIR" remote -v
+
+log "Status:"
+git -C "$SOURCE_DIR" status --short --branch

--- a/scripts/deploy-memento-mcp.sh
+++ b/scripts/deploy-memento-mcp.sh
@@ -235,8 +235,13 @@ need_cmd rsync
 need_cmd cmp
 need_cmd sort
 need_cmd comm
-need_cmd curl
-need_cmd launchctl
+
+if [[ "$RESTART_SERVICE" -eq 1 && "$DRY_RUN" -ne 1 ]]; then
+  need_cmd launchctl
+  if [[ -n "$HEALTH_URL" ]]; then
+    need_cmd curl
+  fi
+fi
 
 [[ -d "$SOURCE_DIR/.git" ]] || die "Source clone is not a git repo: $SOURCE_DIR"
 [[ -d "$LIVE_DIR/.git" ]] || die "Live dir is not a git repo: $LIVE_DIR"

--- a/scripts/deploy-memento-mcp.sh
+++ b/scripts/deploy-memento-mcp.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SOURCE_DIR_DEFAULT="$REPO_ROOT"
+LIVE_DIR_DEFAULT="/Users/kunkun/.adk/release/services/memento-mcp"
+PRESERVE_FILE_DEFAULT="$SCRIPT_DIR/memento-mcp-live-preserve.txt"
+LAUNCHD_LABEL_DEFAULT="com.agentdesk.memento-mcp"
+HEALTH_URL_DEFAULT="http://127.0.0.1:57332/health"
+
+SOURCE_DIR="$SOURCE_DIR_DEFAULT"
+LIVE_DIR="$LIVE_DIR_DEFAULT"
+PRESERVE_FILE="$PRESERVE_FILE_DEFAULT"
+LAUNCHD_LABEL="$LAUNCHD_LABEL_DEFAULT"
+HEALTH_URL="$HEALTH_URL_DEFAULT"
+DRY_RUN=0
+RESTART_SERVICE=1
+RUN_INSTALL_MODE="auto"
+ALLOW_DIRTY_LIVE=0
+PRUNE_REMOVED=1
+INSTALL_REQUIRED=0
+
+declare -a PRESERVE_PATTERNS=()
+
+usage() {
+  cat <<'EOF'
+Usage: deploy-memento-mcp.sh [options]
+
+Options:
+  --source-dir PATH       Canonical source clone
+  --live-dir PATH         Live runtime directory
+  --preserve-file PATH    Glob list of live-local paths to preserve
+  --label LABEL           launchd label to restart
+  --health-url URL        HTTP health check URL
+  --dry-run               Show actions without copying files
+  --no-restart            Do not restart the live service
+  --skip-install          Never sync npm dependencies in the live directory
+  --force-install         Always run npm ci in the live directory
+  --allow-dirty-live      Allow overwriting live tracked files even when they differ
+  --no-prune              Do not remove tracked files missing from source
+  --help                  Show this help
+EOF
+}
+
+log() {
+  printf '[deploy-memento-mcp] %s\n' "$*"
+}
+
+die() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+load_preserve_patterns() {
+  local file="$1"
+  PRESERVE_PATTERNS=()
+
+  if [[ ! -f "$file" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r raw || [[ -n "$raw" ]]; do
+    raw="${raw%%#*}"
+    raw="${raw#"${raw%%[![:space:]]*}"}"
+    raw="${raw%"${raw##*[![:space:]]}"}"
+    [[ -z "$raw" ]] && continue
+    PRESERVE_PATTERNS+=("$raw")
+  done < "$file"
+}
+
+is_preserved_path() {
+  local path="$1"
+  local pattern
+  for pattern in "${PRESERVE_PATTERNS[@]}"; do
+    case "$path" in
+      $pattern) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+filter_path_list() {
+  local input="$1"
+  local output="$2"
+
+  : > "$output"
+  while IFS= read -r path || [[ -n "$path" ]]; do
+    [[ -z "$path" ]] && continue
+    if is_preserved_path "$path"; then
+      continue
+    fi
+    printf '%s\n' "$path" >> "$output"
+  done < "$input"
+
+  sort -u "$output" -o "$output"
+}
+
+print_list_with_prefix() {
+  local prefix="$1"
+  local file="$2"
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" ]] && continue
+    log "$prefix$line"
+  done < "$file"
+}
+
+live_path_matches_source() {
+  local path="$1"
+  local source_path="$SOURCE_DIR/$path"
+  local live_path="$LIVE_DIR/$path"
+
+  if [[ ! -e "$source_path" || ! -e "$live_path" ]]; then
+    return 1
+  fi
+
+  cmp -s "$source_path" "$live_path"
+}
+
+should_run_install() {
+  local install_needed=0
+  local manifest
+
+  if [[ "$RUN_INSTALL_MODE" == "force" ]]; then
+    return 0
+  fi
+
+  if [[ "$RUN_INSTALL_MODE" == "never" ]]; then
+    return 1
+  fi
+
+  if [[ ! -d "$LIVE_DIR/node_modules" ]]; then
+    return 0
+  fi
+
+  for manifest in package.json package-lock.json npm-shrinkwrap.json; do
+    if [[ -e "$SOURCE_DIR/$manifest" ]]; then
+      if [[ ! -e "$LIVE_DIR/$manifest" ]] || ! cmp -s "$SOURCE_DIR/$manifest" "$LIVE_DIR/$manifest"; then
+        install_needed=1
+        break
+      fi
+    fi
+  done
+
+  [[ "$install_needed" -eq 1 ]]
+}
+
+restart_and_check() {
+  local domain="gui/$(id -u)/$LAUNCHD_LABEL"
+  local attempt
+
+  log "Restarting $domain"
+  launchctl kickstart -k "$domain"
+
+  if [[ -z "$HEALTH_URL" ]]; then
+    return 0
+  fi
+
+  log "Waiting for health check: $HEALTH_URL"
+  for attempt in $(seq 1 20); do
+    if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
+      log "Health check passed"
+      return 0
+    fi
+    sleep 1
+  done
+
+  die "Health check failed after restart: $HEALTH_URL"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-dir)
+      SOURCE_DIR="${2:?missing value for --source-dir}"
+      shift 2
+      ;;
+    --live-dir)
+      LIVE_DIR="${2:?missing value for --live-dir}"
+      shift 2
+      ;;
+    --preserve-file)
+      PRESERVE_FILE="${2:?missing value for --preserve-file}"
+      shift 2
+      ;;
+    --label)
+      LAUNCHD_LABEL="${2:?missing value for --label}"
+      shift 2
+      ;;
+    --health-url)
+      HEALTH_URL="${2:?missing value for --health-url}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --no-restart)
+      RESTART_SERVICE=0
+      shift
+      ;;
+    --skip-install)
+      RUN_INSTALL_MODE="never"
+      shift
+      ;;
+    --force-install)
+      RUN_INSTALL_MODE="force"
+      shift
+      ;;
+    --allow-dirty-live)
+      ALLOW_DIRTY_LIVE=1
+      shift
+      ;;
+    --no-prune)
+      PRUNE_REMOVED=0
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+need_cmd git
+need_cmd rsync
+need_cmd cmp
+need_cmd sort
+need_cmd comm
+need_cmd curl
+need_cmd launchctl
+
+[[ -d "$SOURCE_DIR/.git" ]] || die "Source clone is not a git repo: $SOURCE_DIR"
+[[ -d "$LIVE_DIR/.git" ]] || die "Live dir is not a git repo: $LIVE_DIR"
+
+load_preserve_patterns "$PRESERVE_FILE"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+source_all="$tmpdir/source-all.txt"
+live_all="$tmpdir/live-all.txt"
+source_sync="$tmpdir/source-sync.txt"
+live_sync="$tmpdir/live-sync.txt"
+dirty_live="$tmpdir/dirty-live.txt"
+dirty_conflicts="$tmpdir/dirty-conflicts.txt"
+remove_list="$tmpdir/remove-list.txt"
+
+git -C "$SOURCE_DIR" ls-files > "$source_all"
+git -C "$LIVE_DIR" ls-files > "$live_all"
+filter_path_list "$source_all" "$source_sync"
+filter_path_list "$live_all" "$live_sync"
+
+{
+  git -C "$LIVE_DIR" diff --name-only
+  git -C "$LIVE_DIR" diff --cached --name-only
+} | sort -u > "$dirty_live"
+
+: > "$dirty_conflicts"
+while IFS= read -r path || [[ -n "$path" ]]; do
+  [[ -z "$path" ]] && continue
+  if is_preserved_path "$path"; then
+    continue
+  fi
+  if live_path_matches_source "$path"; then
+    continue
+  fi
+  printf '%s\n' "$path" >> "$dirty_conflicts"
+done < "$dirty_live"
+
+if [[ -s "$dirty_conflicts" && "$ALLOW_DIRTY_LIVE" -ne 1 ]]; then
+  log "Live repo has tracked changes that differ from the source clone."
+  print_list_with_prefix "dirty-live-conflict: " "$dirty_conflicts"
+  die "Re-run with --allow-dirty-live after review, or preserve those paths."
+fi
+
+if should_run_install; then
+  INSTALL_REQUIRED=1
+fi
+
+if [[ "$PRUNE_REMOVED" -eq 1 ]]; then
+  comm -23 "$live_sync" "$source_sync" > "$remove_list"
+else
+  : > "$remove_list"
+fi
+
+log "Source clone: $SOURCE_DIR"
+log "Live dir: $LIVE_DIR"
+log "Preserve file: $PRESERVE_FILE"
+
+if [[ ${#PRESERVE_PATTERNS[@]} -gt 0 ]]; then
+  local_pattern_file="$tmpdir/preserve-patterns.txt"
+  printf '%s\n' "${PRESERVE_PATTERNS[@]}" > "$local_pattern_file"
+  print_list_with_prefix "preserve: " "$local_pattern_file"
+fi
+
+if [[ -s "$remove_list" ]]; then
+  print_list_with_prefix "remove: " "$remove_list"
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  log "Dry-run sync preview"
+  rsync -avn --files-from="$source_sync" "$SOURCE_DIR"/ "$LIVE_DIR"/
+  if [[ "$INSTALL_REQUIRED" -eq 1 ]]; then
+    log "would run: npm ci"
+  fi
+  if [[ "$RESTART_SERVICE" -eq 1 ]]; then
+    log "would restart launchd label: $LAUNCHD_LABEL"
+  fi
+  exit 0
+fi
+
+if [[ -s "$remove_list" ]]; then
+  while IFS= read -r path || [[ -n "$path" ]]; do
+    [[ -z "$path" ]] && continue
+    rm -f "$LIVE_DIR/$path"
+  done < "$remove_list"
+fi
+
+rsync -a --files-from="$source_sync" "$SOURCE_DIR"/ "$LIVE_DIR"/
+
+if [[ "$INSTALL_REQUIRED" -eq 1 ]]; then
+  if [[ ! -f "$LIVE_DIR/package-lock.json" && ! -f "$LIVE_DIR/npm-shrinkwrap.json" ]]; then
+    die "Deterministic deploy requires package-lock.json or npm-shrinkwrap.json in $LIVE_DIR"
+  fi
+
+  log "Running npm ci in $LIVE_DIR"
+  (
+    cd "$LIVE_DIR"
+    npm ci
+  )
+else
+  log "Skipping npm dependency sync"
+fi
+
+if [[ "$RESTART_SERVICE" -eq 1 ]]; then
+  restart_and_check
+else
+  log "Skipping restart"
+fi
+
+log "Deploy complete"

--- a/scripts/memento-mcp-live-preserve.txt
+++ b/scripts/memento-mcp-live-preserve.txt
@@ -1,0 +1,10 @@
+# Paths in the live runtime repo that should stay local-only.
+# Shell case patterns are supported.
+
+config/memory.js
+.env
+.env.*
+logs
+logs/**
+node_modules
+node_modules/**

--- a/tests/unit/auxiliary-section-planner.test.js
+++ b/tests/unit/auxiliary-section-planner.test.js
@@ -1,0 +1,56 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildHeuristicAuxiliaryPlan,
+  planAuxiliarySections
+} from "../../lib/memory/AuxiliarySectionPlanner.js";
+
+describe("AuxiliarySectionPlanner", () => {
+  it("heuristic planner가 debugging 질의에서 error_playbook을 고른다", () => {
+    const result = buildHeuristicAuxiliaryPlan({
+      contextText: "에러 원인과 디버깅 힌트가 필요하다",
+      phase      : "debugging",
+      maxSections: 3
+    });
+
+    assert.ok(result.sections.includes("error_playbook"));
+  });
+
+  it("LLM planner 결과를 sanitize하여 허용된 섹션만 유지한다", async () => {
+    const llmJsonFn = mock.fn(async () => ({
+      sections : ["decision_memory", "invalid_section", "case_memory"],
+      rationale: "planning + history"
+    }));
+    const isLlmAvailableFn = mock.fn(async () => true);
+
+    const result = await planAuxiliarySections({
+      contextText      : "왜 이렇게 설계했고 이전 비슷한 케이스가 있었는지 보고 싶다",
+      maxSections      : 3,
+      llmJsonFn,
+      isLlmAvailableFn
+    });
+
+    assert.deepEqual(result.sections, ["decision_memory", "case_memory"]);
+    assert.equal(result.source, "llm");
+  });
+
+  it("LLM 실패 시 heuristic fallback을 사용한다", async () => {
+    const llmJsonFn = mock.fn(async () => {
+      throw new Error("llm down");
+    });
+    const isLlmAvailableFn = mock.fn(async () => true);
+
+    const result = await planAuxiliarySections({
+      contextText      : "이전에 비슷했던 사례랑 미해결 질문이 있나",
+      resolutionStatus : "open",
+      maxSections      : 5,
+      llmJsonFn,
+      isLlmAvailableFn
+    });
+
+    assert.equal(result.source, "heuristic");
+    assert.ok(result.sections.includes("case_memory"));
+    assert.ok(result.sections.includes("open_questions_memory"));
+  });
+});

--- a/tests/unit/context-builder.test.js
+++ b/tests/unit/context-builder.test.js
@@ -201,6 +201,39 @@ describe("ContextBuilder.build()", () => {
     assert.doesNotMatch(result.injectionText, /default learning content/);
   });
 
+  it("hardening=false 에서 recall 경로의 learning_extraction 파편은 core memory에 유지된다", async () => {
+    recallMock = mock.fn(async (params) => {
+      if (params.topic === "session_reflect") {
+        return { fragments: [] };
+      }
+      if (params.type === "fact") {
+        return {
+          fragments: [
+            frag("fact-learning-1", "fact", "legacy learning fact", { source: "learning_extraction" }),
+          ],
+        };
+      }
+      return { fragments: [] };
+    });
+    builder = new ContextBuilder({
+      recall : recallMock,
+      store  : storeMock,
+      index  : indexMock,
+      getPool: () => null,
+    });
+
+    const flatResult = await builder.build({ types: ["fact"] });
+    assert.ok(flatResult.fragments.some(f => f.id === "fact-learning-1"));
+    assert.match(flatResult.injectionText, /\[CORE MEMORY\]/);
+    assert.match(flatResult.injectionText, /\[FACT\]/);
+    assert.match(flatResult.injectionText, /legacy learning fact/);
+    assert.doesNotMatch(flatResult.injectionText, /\[LEARNING MEMORY\]/);
+
+    const structuredResult = await builder.build({ types: ["fact"], structured: true });
+    assert.equal(structuredResult.core.fact.length, 1);
+    assert.equal(structuredResult.core.fact[0].id, "fact-learning-1");
+  });
+
   it("structured=true 시 learning 파편이 rankedInjection에는 포함되고 core 중복 분류는 되지 않는다 (hardening=true)", async () => {
     storeMock.searchBySource = mock.fn(async () => [
       frag("learn-1", "fact", "learning content", { source: "learning_extraction", importance: 0.95 })

--- a/tests/unit/context-builder.test.js
+++ b/tests/unit/context-builder.test.js
@@ -163,6 +163,88 @@ describe("ContextBuilder.build()", () => {
     assert.equal(typeof result.count, "number");
   });
 
+  it("learning 파편이 flat injectionText와 fragments에 포함된다 (hardening=true)", async () => {
+    storeMock.searchBySource = mock.fn(async () => [
+      frag("learn-1", "fact", "learning content", { source: "learning_extraction" })
+    ]);
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      hardeningEnabled: true,
+    });
+
+    const result = await builder.build({});
+
+    assert.ok(result.fragments.some(f => f.id === "learn-1"));
+    assert.match(result.injectionText, /\[LEARNING MEMORY\]/);
+    assert.match(result.injectionText, /learning content/);
+  });
+
+  it("config 기본값(hardening=false)에서는 learning 파편을 주입하지 않는다", async () => {
+    storeMock.searchBySource = mock.fn(async () => [
+      frag("learn-default", "fact", "default learning content", { source: "learning_extraction" })
+    ]);
+    builder = new ContextBuilder({
+      recall : recallMock,
+      store  : storeMock,
+      index  : indexMock,
+      getPool: () => null,
+    });
+
+    const result = await builder.build({});
+
+    assert.equal(storeMock.searchBySource.mock.callCount(), 0);
+    assert.ok(!result.fragments.some(f => f.id === "learn-default"));
+    assert.doesNotMatch(result.injectionText, /\[LEARNING MEMORY\]/);
+    assert.doesNotMatch(result.injectionText, /default learning content/);
+  });
+
+  it("structured=true 시 learning 파편이 rankedInjection에는 포함되고 core 중복 분류는 되지 않는다 (hardening=true)", async () => {
+    storeMock.searchBySource = mock.fn(async () => [
+      frag("learn-1", "fact", "learning content", { source: "learning_extraction", importance: 0.95 })
+    ]);
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      hardeningEnabled: true,
+    });
+
+    const result = await builder.build({ structured: true });
+
+    assert.equal(result.learning.recent.length, 1);
+    assert.equal(result.learning.recent[0].id, "learn-1");
+    assert.ok(result.rankedInjection.items.some(item => item.id === "learn-1"));
+    assert.ok(!(result.core.fact || []).some(f => f.id === "learn-1"));
+  });
+
+  it("anchor query에 workspace 필터를 적용하고 rankedInjection에서 anchor로 고정한다 (hardening=true)", async () => {
+    const poolMock = {
+      query: mock.fn(async () => ({
+        rows: [frag("anchor-1", "decision", "anchor content", { is_anchor: true, importance: 1.0 })]
+      }))
+    };
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => poolMock,
+      hardeningEnabled: true,
+    });
+
+    const result = await builder.build({ structured: true, workspace: "maker" });
+
+    assert.equal(poolMock.query.mock.callCount(), 1);
+    const [sql, params] = poolMock.query.mock.calls[0].arguments;
+    assert.match(sql, /workspace = \$\d+ OR workspace IS NULL/);
+    assert.deepEqual(params, ["maker"]);
+    assert.equal(result.rankedInjection.items[0].id, "anchor-1");
+    assert.equal(result.rankedInjection.items[0].anchor, true);
+  });
+
   it("파편이 비어 있으면 _memento_hint에 empty_context 포함", async () => {
     recallMock = mock.fn(async () => ({ fragments: [] }));
     builder    = new ContextBuilder({ recall: recallMock, store: storeMock, index: indexMock, getPool: () => null });
@@ -185,5 +267,75 @@ describe("ContextBuilder.build()", () => {
     const result = await builder.build({});
     assert.ok(result._memento_hint);
     assert.equal(result._memento_hint.signal, "active_errors");
+  });
+
+  /* ── hardening=false 회귀 테스트 (명시적 레거시 호환 모드 검증) ── */
+
+  it("hardening=false(명시적 호환 모드): searchBySource를 호출하지 않는다", async () => {
+    storeMock.searchBySource = mock.fn(async () => [
+      frag("learn-1", "fact", "should not appear")
+    ]);
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      hardeningEnabled: false,
+    });
+
+    await builder.build({});
+    assert.equal(storeMock.searchBySource.mock.callCount(), 0);
+  });
+
+  it("hardening=false: injectionText에 [LEARNING MEMORY]가 없다", async () => {
+    storeMock.searchBySource = mock.fn(async () => [
+      frag("learn-1", "fact", "learning content")
+    ]);
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      hardeningEnabled: false,
+    });
+
+    const result = await builder.build({});
+    assert.ok(!result.injectionText.includes("[LEARNING MEMORY]"));
+    assert.ok(!result.fragments.some(f => f.id === "learn-1"));
+  });
+
+  it("hardening=false: is_anchor=true 파편이 있어도 rankedInjection에서 anchor로 고정되지 않는다", async () => {
+    const poolMock = {
+      query: mock.fn(async () => ({
+        rows: [frag("anchor-1", "decision", "anchor content", { is_anchor: true, importance: 1.0 })]
+      }))
+    };
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => poolMock,
+      hardeningEnabled: false,
+    });
+
+    const result = await builder.build({ structured: true, workspace: "maker" });
+    // legacy 필터(f.type === "anchor")는 항상 빈 배열 → 첫 항목은 anchor:false
+    assert.ok(result.rankedInjection.items.length > 0);
+    assert.equal(result.rankedInjection.items[0].anchor, false);
+  });
+
+  it("hardening=false: 기본 recall 동작과 fragments 반환은 hardening=true와 동일하다", async () => {
+    const builderOff = new ContextBuilder({
+      recall: recallMock, store: storeMock, index: indexMock, getPool: () => null, hardeningEnabled: false,
+    });
+    const builderOn = new ContextBuilder({
+      recall: recallMock, store: storeMock, index: indexMock, getPool: () => null, hardeningEnabled: true,
+    });
+
+    const off = await builderOff.build({});
+    const on  = await builderOn.build({});
+    // learning이 없는 환경에서는 fragments 수가 동일해야 한다
+    assert.equal(off.fragments.length, on.fragments.length);
+    assert.equal(off.wmCount, on.wmCount);
   });
 });

--- a/tests/unit/context-builder.test.js
+++ b/tests/unit/context-builder.test.js
@@ -221,6 +221,29 @@ describe("ContextBuilder.build()", () => {
     assert.ok(!(result.core.fact || []).some(f => f.id === "learn-1"));
   });
 
+  it("hardening=true 에서 learning 파편 여러 개가 fragments와 rankedInjection에 모두 유지된다", async () => {
+    storeMock.searchBySource = mock.fn(async () => [
+      frag("learn-1", "fact", "learning content 1", { source: "learning_extraction", importance: 0.95 }),
+      frag("learn-2", "fact", "learning content 2", { source: "learning_extraction", importance: 0.9 }),
+    ]);
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      hardeningEnabled: true,
+    });
+
+    const flatResult = await builder.build({});
+    assert.ok(flatResult.fragments.some(f => f.id === "learn-1"));
+    assert.ok(flatResult.fragments.some(f => f.id === "learn-2"));
+
+    const structuredResult = await builder.build({ structured: true });
+    assert.equal(structuredResult.learning.recent.length, 2);
+    assert.ok(structuredResult.rankedInjection.items.some(item => item.id === "learn-1"));
+    assert.ok(structuredResult.rankedInjection.items.some(item => item.id === "learn-2"));
+  });
+
   it("anchor query에 workspace 필터를 적용하고 rankedInjection에서 anchor로 고정한다 (hardening=true)", async () => {
     const poolMock = {
       query: mock.fn(async () => ({

--- a/tests/unit/context-builder.test.js
+++ b/tests/unit/context-builder.test.js
@@ -277,6 +277,34 @@ describe("ContextBuilder.build()", () => {
     assert.ok(structuredResult.rankedInjection.items.some(item => item.id === "learn-2"));
   });
 
+  it("hardening=true 에서 budget 밖 learning 파편은 LEARNING 섹션과 structured learning에도 포함되지 않는다", async () => {
+    storeMock.searchBySource = mock.fn(async () => [
+      frag("learn-big-1", "fact", "a".repeat(4000), { source: "learning_extraction", importance: 0.95 }),
+      frag("learn-big-2", "fact", "b".repeat(4000), { source: "learning_extraction", importance: 0.9 }),
+    ]);
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      hardeningEnabled: true,
+    });
+
+    const flatResult = await builder.build({});
+    assert.ok(flatResult.fragments.some(f => f.id === "learn-big-1"));
+    assert.ok(flatResult.fragments.some(f => f.id === "learn-big-2"));
+    assert.match(flatResult.injectionText, /a{20}/);
+    assert.match(flatResult.injectionText, /b{20}/);
+    assert.doesNotMatch(flatResult.injectionText, /b{3000}/);
+
+    const structuredResult = await builder.build({ structured: true });
+    assert.equal(structuredResult.learning.recent.length, 2);
+    assert.equal(structuredResult.learning.recent[0].id, "learn-big-1");
+    assert.equal(structuredResult.learning.recent[1].id, "learn-big-2");
+    assert.ok(structuredResult.learning.recent[1].content.length < 4000);
+    assert.match(structuredResult.learning.recent[1].content, /\.\.\.$/);
+  });
+
   it("anchor query에 workspace 필터를 적용하고 rankedInjection에서 anchor로 고정한다 (hardening=true)", async () => {
     const poolMock = {
       query: mock.fn(async () => ({

--- a/tests/unit/context-builder.test.js
+++ b/tests/unit/context-builder.test.js
@@ -72,6 +72,7 @@ describe("ContextBuilder.build()", () => {
   let recallMock;
   let indexMock;
   let storeMock;
+  let auxiliaryPlannerMock;
   let builder;
 
   beforeEach(() => {
@@ -96,11 +97,14 @@ describe("ContextBuilder.build()", () => {
       searchBySource: mock.fn(async () => []),
     };
 
+    auxiliaryPlannerMock = mock.fn(async () => ({ sections: [] }));
+
     builder = new ContextBuilder({
-      recall : recallMock,
-      store  : storeMock,
-      index  : indexMock,
-      getPool: () => null,
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      auxiliaryPlanner: auxiliaryPlannerMock,
     });
   });
 
@@ -142,7 +146,13 @@ describe("ContextBuilder.build()", () => {
         fragments: [frag("dup-1", params.type, `${params.type} content`)]
       };
     });
-    builder = new ContextBuilder({ recall: recallMock, store: storeMock, index: indexMock, getPool: () => null });
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      auxiliaryPlanner: auxiliaryPlannerMock,
+    });
 
     const result = await builder.build({ types: ["error", "preference"] });
     const ids    = result.fragments.map(f => f.id);
@@ -167,12 +177,14 @@ describe("ContextBuilder.build()", () => {
     storeMock.searchBySource = mock.fn(async () => [
       frag("learn-1", "fact", "learning content", { source: "learning_extraction" })
     ]);
+    auxiliaryPlannerMock = mock.fn(async () => ({ sections: ["learning_memory"] }));
     builder = new ContextBuilder({
       recall          : recallMock,
       store           : storeMock,
       index           : indexMock,
       getPool         : () => null,
       hardeningEnabled: true,
+      auxiliaryPlanner: auxiliaryPlannerMock,
     });
 
     const result = await builder.build({});
@@ -182,15 +194,113 @@ describe("ContextBuilder.build()", () => {
     assert.match(result.injectionText, /learning content/);
   });
 
+  it("hardening=true + contextText가 있으면 learning_extraction을 query-aware recall로 먼저 붙인다", async () => {
+    recallMock = mock.fn(async (params) => {
+      if (params.topic === "session_reflect") {
+        return { fragments: [] };
+      }
+      if (params.source === "learning_extraction") {
+        return {
+          fragments: [
+            frag("learn-query-1", "fact", "query matched learning", { source: "learning_extraction" })
+          ]
+        };
+      }
+      return {
+        fragments: [
+          frag(`${params.type}-1`, params.type, `${params.type} content 1`),
+          frag(`${params.type}-2`, params.type, `${params.type} content 2`),
+        ]
+      };
+    });
+    storeMock.searchBySource = mock.fn(async () => [
+      frag("learn-fallback", "fact", "fallback learning", { source: "learning_extraction" })
+    ]);
+    auxiliaryPlannerMock = mock.fn(async () => ({ sections: ["learning_memory"] }));
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      hardeningEnabled: true,
+      auxiliaryPlanner: auxiliaryPlannerMock,
+    });
+
+    const result = await builder.build({
+      contextText     : "현재 user 질의",
+      caseId          : "case-123",
+      resolutionStatus: "open",
+      phase           : "debugging"
+    });
+
+    assert.ok(result.fragments.some(f => f.id === "learn-query-1"));
+    assert.equal(storeMock.searchBySource.mock.callCount(), 0);
+
+    const learningCall = recallMock.mock.calls.find(call => call.arguments[0].source === "learning_extraction");
+    assert.ok(learningCall);
+    assert.equal(learningCall.arguments[0].text, "현재 user 질의");
+    assert.equal(learningCall.arguments[0].contextText, "현재 user 질의");
+    assert.equal(learningCall.arguments[0].caseId, "case-123");
+    assert.equal(learningCall.arguments[0].resolutionStatus, "open");
+    assert.equal(learningCall.arguments[0].phase, "debugging");
+    assert.equal(learningCall.arguments[0].includeLinks, false);
+  });
+
+  it("query-aware learning recall 결과가 없으면 source fallback으로 최근 learning을 붙인다", async () => {
+    recallMock = mock.fn(async (params) => {
+      if (params.topic === "session_reflect") {
+        return { fragments: [] };
+      }
+      if (params.source === "learning_extraction") {
+        return { fragments: [] };
+      }
+      return {
+        fragments: [
+          frag(`${params.type}-1`, params.type, `${params.type} content 1`),
+          frag(`${params.type}-2`, params.type, `${params.type} content 2`),
+        ]
+      };
+    });
+    storeMock.searchBySource = mock.fn(async () => [
+      frag("learn-fallback-1", "fact", "fallback learning", {
+        source           : "learning_extraction",
+        case_id          : "case-123",
+        resolution_status: "open",
+        phase            : "debugging"
+      })
+    ]);
+    auxiliaryPlannerMock = mock.fn(async () => ({ sections: ["learning_memory"] }));
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      hardeningEnabled: true,
+      auxiliaryPlanner: auxiliaryPlannerMock,
+    });
+
+    const result = await builder.build({
+      contextText     : "현재 user 질의",
+      caseId          : "case-123",
+      resolutionStatus: "open",
+      phase           : "debugging"
+    });
+
+    assert.equal(storeMock.searchBySource.mock.callCount(), 1);
+    assert.ok(result.fragments.some(f => f.id === "learn-fallback-1"));
+    assert.match(result.injectionText, /fallback learning/);
+  });
+
   it("config 기본값(hardening=false)에서는 learning 파편을 주입하지 않는다", async () => {
     storeMock.searchBySource = mock.fn(async () => [
       frag("learn-default", "fact", "default learning content", { source: "learning_extraction" })
     ]);
     builder = new ContextBuilder({
-      recall : recallMock,
-      store  : storeMock,
-      index  : indexMock,
-      getPool: () => null,
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      auxiliaryPlanner: auxiliaryPlannerMock,
     });
 
     const result = await builder.build({});
@@ -238,12 +348,14 @@ describe("ContextBuilder.build()", () => {
     storeMock.searchBySource = mock.fn(async () => [
       frag("learn-1", "fact", "learning content", { source: "learning_extraction", importance: 0.95 })
     ]);
+    auxiliaryPlannerMock = mock.fn(async () => ({ sections: ["learning_memory"] }));
     builder = new ContextBuilder({
       recall          : recallMock,
       store           : storeMock,
       index           : indexMock,
       getPool         : () => null,
       hardeningEnabled: true,
+      auxiliaryPlanner: auxiliaryPlannerMock,
     });
 
     const result = await builder.build({ structured: true });
@@ -259,12 +371,14 @@ describe("ContextBuilder.build()", () => {
       frag("learn-1", "fact", "learning content 1", { source: "learning_extraction", importance: 0.95 }),
       frag("learn-2", "fact", "learning content 2", { source: "learning_extraction", importance: 0.9 }),
     ]);
+    auxiliaryPlannerMock = mock.fn(async () => ({ sections: ["learning_memory"] }));
     builder = new ContextBuilder({
       recall          : recallMock,
       store           : storeMock,
       index           : indexMock,
       getPool         : () => null,
       hardeningEnabled: true,
+      auxiliaryPlanner: auxiliaryPlannerMock,
     });
 
     const flatResult = await builder.build({});
@@ -277,32 +391,32 @@ describe("ContextBuilder.build()", () => {
     assert.ok(structuredResult.rankedInjection.items.some(item => item.id === "learn-2"));
   });
 
-  it("hardening=true 에서 budget 밖 learning 파편은 LEARNING 섹션과 structured learning에도 포함되지 않는다", async () => {
+  it("hardening=true 에서 보조 섹션 예산을 넘는 learning 파편은 뒤쪽 항목이 잘린다", async () => {
     storeMock.searchBySource = mock.fn(async () => [
       frag("learn-big-1", "fact", "a".repeat(4000), { source: "learning_extraction", importance: 0.95 }),
       frag("learn-big-2", "fact", "b".repeat(4000), { source: "learning_extraction", importance: 0.9 }),
     ]);
+    auxiliaryPlannerMock = mock.fn(async () => ({ sections: ["learning_memory"] }));
     builder = new ContextBuilder({
       recall          : recallMock,
       store           : storeMock,
       index           : indexMock,
       getPool         : () => null,
       hardeningEnabled: true,
+      auxiliaryPlanner: auxiliaryPlannerMock,
     });
 
     const flatResult = await builder.build({});
     assert.ok(flatResult.fragments.some(f => f.id === "learn-big-1"));
-    assert.ok(flatResult.fragments.some(f => f.id === "learn-big-2"));
+    assert.ok(!flatResult.fragments.some(f => f.id === "learn-big-2"));
     assert.match(flatResult.injectionText, /a{20}/);
-    assert.match(flatResult.injectionText, /b{20}/);
-    assert.doesNotMatch(flatResult.injectionText, /b{3000}/);
+    assert.doesNotMatch(flatResult.injectionText, /b{20}/);
 
     const structuredResult = await builder.build({ structured: true });
-    assert.equal(structuredResult.learning.recent.length, 2);
+    assert.equal(structuredResult.learning.recent.length, 1);
     assert.equal(structuredResult.learning.recent[0].id, "learn-big-1");
-    assert.equal(structuredResult.learning.recent[1].id, "learn-big-2");
-    assert.ok(structuredResult.learning.recent[1].content.length < 4000);
-    assert.match(structuredResult.learning.recent[1].content, /\.\.\.$/);
+    assert.ok(structuredResult.learning.recent[0].content.length < 4000);
+    assert.match(structuredResult.learning.recent[0].content, /\.\.\.$/);
   });
 
   it("anchor query에 workspace 필터를 적용하고 rankedInjection에서 anchor로 고정한다 (hardening=true)", async () => {
@@ -317,6 +431,7 @@ describe("ContextBuilder.build()", () => {
       index           : indexMock,
       getPool         : () => poolMock,
       hardeningEnabled: true,
+      auxiliaryPlanner: auxiliaryPlannerMock,
     });
 
     const result = await builder.build({ structured: true, workspace: "maker" });
@@ -329,9 +444,60 @@ describe("ContextBuilder.build()", () => {
     assert.equal(result.rankedInjection.items[0].anchor, true);
   });
 
+  it("planner가 선택한 error/decision 보조 섹션만 추가로 붙인다", async () => {
+    recallMock = mock.fn(async (params) => {
+      if (params.topic === "session_reflect") return { fragments: [] };
+      if (params.type === "error" && params.text) {
+        return { fragments: [frag("err-aux-1", "error", "targeted error playbook")] };
+      }
+      if (params.type === "decision" && params.text) {
+        return { fragments: [frag("dec-aux-1", "decision", "targeted decision memory")] };
+      }
+      return {
+        fragments: [
+          frag(`${params.type}-1`, params.type, `${params.type} content 1`),
+          frag(`${params.type}-2`, params.type, `${params.type} content 2`),
+        ]
+      };
+    });
+    auxiliaryPlannerMock = mock.fn(async () => ({
+      sections: ["error_playbook", "decision_memory"]
+    }));
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      hardeningEnabled: true,
+      auxiliaryPlanner: auxiliaryPlannerMock,
+    });
+
+    const flatResult = await builder.build({
+      contextText: "현재 에러 원인과 설계 결정을 같이 보고 싶다"
+    });
+
+    assert.match(flatResult.injectionText, /\[ERROR PLAYBOOK\]/);
+    assert.match(flatResult.injectionText, /targeted error playbook/);
+    assert.match(flatResult.injectionText, /\[DECISION MEMORY\]/);
+    assert.match(flatResult.injectionText, /targeted decision memory/);
+
+    const structuredResult = await builder.build({
+      contextText: "현재 에러 원인과 설계 결정을 같이 보고 싶다",
+      structured : true
+    });
+    assert.equal(structuredResult.auxiliary.errorPlaybook.length, 1);
+    assert.equal(structuredResult.auxiliary.decisionMemory.length, 1);
+  });
+
   it("파편이 비어 있으면 _memento_hint에 empty_context 포함", async () => {
     recallMock = mock.fn(async () => ({ fragments: [] }));
-    builder    = new ContextBuilder({ recall: recallMock, store: storeMock, index: indexMock, getPool: () => null });
+    builder    = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      auxiliaryPlanner: auxiliaryPlannerMock,
+    });
 
     const result = await builder.build({});
     assert.ok(result._memento_hint);
@@ -346,7 +512,13 @@ describe("ContextBuilder.build()", () => {
       }
       return { fragments: [] };
     });
-    builder = new ContextBuilder({ recall: recallMock, store: storeMock, index: indexMock, getPool: () => null });
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      auxiliaryPlanner: auxiliaryPlannerMock,
+    });
 
     const result = await builder.build({});
     assert.ok(result._memento_hint);
@@ -365,6 +537,7 @@ describe("ContextBuilder.build()", () => {
       index           : indexMock,
       getPool         : () => null,
       hardeningEnabled: false,
+      auxiliaryPlanner: auxiliaryPlannerMock,
     });
 
     await builder.build({});
@@ -381,6 +554,7 @@ describe("ContextBuilder.build()", () => {
       index           : indexMock,
       getPool         : () => null,
       hardeningEnabled: false,
+      auxiliaryPlanner: auxiliaryPlannerMock,
     });
 
     const result = await builder.build({});
@@ -400,6 +574,7 @@ describe("ContextBuilder.build()", () => {
       index           : indexMock,
       getPool         : () => poolMock,
       hardeningEnabled: false,
+      auxiliaryPlanner: auxiliaryPlannerMock,
     });
 
     const result = await builder.build({ structured: true, workspace: "maker" });
@@ -410,10 +585,10 @@ describe("ContextBuilder.build()", () => {
 
   it("hardening=false: 기본 recall 동작과 fragments 반환은 hardening=true와 동일하다", async () => {
     const builderOff = new ContextBuilder({
-      recall: recallMock, store: storeMock, index: indexMock, getPool: () => null, hardeningEnabled: false,
+      recall: recallMock, store: storeMock, index: indexMock, getPool: () => null, hardeningEnabled: false, auxiliaryPlanner: auxiliaryPlannerMock,
     });
     const builderOn = new ContextBuilder({
-      recall: recallMock, store: storeMock, index: indexMock, getPool: () => null, hardeningEnabled: true,
+      recall: recallMock, store: storeMock, index: indexMock, getPool: () => null, hardeningEnabled: true, auxiliaryPlanner: auxiliaryPlannerMock,
     });
 
     const off = await builderOff.build({});

--- a/tests/unit/fragment-search-source-filter.test.js
+++ b/tests/unit/fragment-search-source-filter.test.js
@@ -1,0 +1,59 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+import { FragmentSearch } from "../../lib/memory/FragmentSearch.js";
+
+describe("FragmentSearch source filter", () => {
+  it("source-only query는 L2에서 searchBySource fallback을 사용한다", async () => {
+    const search = new FragmentSearch();
+    search.store = {
+      searchByKeywords: mock.fn(async () => []),
+      searchByTopic   : mock.fn(async () => []),
+      searchBySource  : mock.fn(async () => [
+        { id: "learn-1", content: "learning", source: "learning_extraction", importance: 0.8 }
+      ]),
+      getByIds        : mock.fn(async () => [])
+    };
+
+    const results = await search._searchL2(
+      { source: "learning_extraction", minImportance: 0.3, workspace: "maker" },
+      [],
+      "default",
+      null,
+      null
+    );
+
+    assert.equal(search.store.searchBySource.mock.callCount(), 1);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].id, "learn-1");
+  });
+
+  it("_executeSearch는 HotCache/L1 경로에서도 source 후처리 필터를 적용한다", async () => {
+    const search = new FragmentSearch();
+    search._searchL1 = mock.fn(async () => ({ ids: ["keep", "drop"], isFallback: false }));
+    search._tryHotCache = mock.fn(async () => [
+      { id: "keep", content: "matched learning", source: "learning_extraction" },
+      { id: "drop", content: "other source", source: "session:abcd" }
+    ]);
+    search._searchL2 = mock.fn(async () => []);
+    search._searchL3 = mock.fn(async () => []);
+    search._searchTemporal = mock.fn(async () => []);
+
+    const result = await search._executeSearch(
+      {
+        source    : "learning_extraction",
+        agentId   : "default",
+        keyId     : null,
+        workspace : null,
+        timeRange : null,
+        text      : null,
+        caseId    : undefined,
+        phase     : undefined,
+        resolutionStatus: undefined
+      },
+      Promise.resolve({ record: () => {} })
+    );
+
+    assert.deepEqual(result.combined.map(f => f.id), ["keep"]);
+  });
+});

--- a/tests/unit/memory-manager-recall-source-filter.test.js
+++ b/tests/unit/memory-manager-recall-source-filter.test.js
@@ -1,0 +1,46 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+import { MemoryManager } from "../../lib/memory/MemoryManager.js";
+
+describe("MemoryManager.recall source-aware filters", () => {
+  it("passes source and execution filters through to FragmentSearch", async () => {
+    const searchMock = {
+      search: mock.fn(async () => ({
+        fragments : [{ id: "learn-1", content: "learning hit", source: "learning_extraction" }],
+        totalTokens: 12,
+        searchPath : "L2",
+        count      : 1
+      }))
+    };
+    const storeMock = {
+      getLinkedFragments: mock.fn(async () => [])
+    };
+
+    const mm = MemoryManager.create({ search: searchMock, store: storeMock });
+
+    const result = await mm.recall({
+      agentId         : "default",
+      workspace       : "maker",
+      source          : "learning_extraction",
+      caseId          : "case-123",
+      resolutionStatus: "open",
+      phase           : "debugging",
+      includeLinks    : false,
+      tokenBudget     : 200
+    });
+
+    assert.equal(searchMock.search.mock.callCount(), 1);
+
+    const call = searchMock.search.mock.calls[0].arguments[0];
+    assert.equal(call.source, "learning_extraction");
+    assert.equal(call.caseId, "case-123");
+    assert.equal(call.resolutionStatus, "open");
+    assert.equal(call.phase, "debugging");
+    assert.equal(call.workspace, "maker");
+    assert.equal(call.agentId, "default");
+
+    assert.equal(result.fragments.length, 1);
+    assert.equal(result.fragments[0].id, "learn-1");
+  });
+});


### PR DESCRIPTION
## Summary
- change `contextInjection.hardening.enabled` default to `false`
- keep hardening behavior available only through explicit opt-in
- preserve legacy learning-fragment behavior when `hardening=false`
- keep hardening-mode learning injection aligned with accounted context budget
- add a local source-clone bootstrap + live deploy workflow for `memento-mcp`

## Why
The current hardening behavior changes context injection semantics by enabling learning injection and `is_anchor`-based anchor pinning. Keeping that path opt-in preserves legacy behavior for existing consumers and makes rollout safer across mixed AgentDesk and memento-mcp versions.

The repo also needed an operationally safe path to manage a canonical local source clone and deploy it into the live runtime without clobbering live-local config.

## Changes
- `config/memory.js`
  - set `contextInjection.hardening.enabled` default to `false`
- `lib/memory/ContextBuilder.js`
  - document default `false`
  - preserve hardening path behind explicit `hardeningEnabled: true`
  - keep multi-fragment learning results in the synthetic `learning` bucket when hardening is enabled
  - keep recall-returned `learning_extraction` fragments visible in legacy mode
  - ensure `[LEARNING MEMORY]` / structured `learning.recent` use only accounting-selected learning fragments
- `tests/unit/context-builder.test.js`
  - assert default config does not inject learning fragments loaded via `searchBySource`
  - keep explicit `hardening=true` behavior covered
  - keep legacy compatibility regression coverage for `hardening=false`
  - add regression coverage for multiple learning fragments
  - add regression coverage for budget-truncated learning fragments
- `docs/configuration.md`
- `docs/configuration.en.md`
- `CHANGELOG.md`
- `scripts/bootstrap-memento-mcp-source.sh`
  - bootstrap/repair canonical local source clone remotes
- `scripts/deploy-memento-mcp.sh`
  - sync tracked source files into live runtime with preserve list, dirty-live guard, optional restart, and health check
  - defer `launchctl` / `curl` requirements when restart is disabled or the run is a dry-run
- `scripts/memento-mcp-live-preserve.txt`
  - preserve live-local config/env/log/node_modules paths
- `docs/operations/local-source-deploy.md`
  - document canonical source/live runtime workflow

## Verification
- `node --experimental-test-module-mocks --test tests/unit/context-builder.test.js tests/unit/context-structured.test.js`
- result: `31/31` passing
- `bash -n scripts/bootstrap-memento-mcp-source.sh scripts/deploy-memento-mcp.sh`
- `scripts/deploy-memento-mcp.sh --dry-run --no-restart`
  - reached dirty-live conflict guard instead of failing on unconditional `launchctl` / `curl` requirements

## Compatibility
- default behavior remains legacy-compatible
- consumers that want hardening must explicitly set `contextInjection.hardening.enabled: true`
- local deploy preserves `config/memory.js`, `.env*`, `logs/**`, and `node_modules/**` by default