### PR TITLE
feat(context): enable hardening and auxiliary planning

### DIFF
--- a/config/memory.js
+++ b/config/memory.js
@@ -98,7 +98,7 @@ export const MEMORY_CONFIG = {
      *
      * 신규 동작이 필요한 소비자만 이 값을 명시적으로 true로 올려 opt-in 한다.
      */
-    hardeningEnabled   : false,
+    hardeningEnabled   : true,
     /**
      * hardening 경로에서 보조 섹션 선정을 LLM planner로 위임할지 여부.
      *

--- a/lib/memory/ContextBuilder.js
+++ b/lib/memory/ContextBuilder.js
@@ -202,17 +202,14 @@ export class ContextBuilder {
             agentId,
             groupKeyIds,
             5,
-            workspace
+            workspace,
+            false,
+            {
+              ...(params.caseId ? { caseId: params.caseId } : {}),
+              ...(params.resolutionStatus ? { resolutionStatus: params.resolutionStatus } : {}),
+              ...(params.phase ? { phase: params.phase } : {})
+            }
           );
-          if (params.caseId) {
-            fragments = fragments.filter(f => f.case_id === params.caseId);
-          }
-          if (params.resolutionStatus) {
-            fragments = fragments.filter(f => f.resolution_status === params.resolutionStatus);
-          }
-          if (params.phase) {
-            fragments = fragments.filter(f => f.phase === params.phase);
-          }
         }
 
         fragments = capFragmentsToBudget(fragments, auxiliaryCharBudget);

--- a/lib/memory/ContextBuilder.js
+++ b/lib/memory/ContextBuilder.js
@@ -200,7 +200,7 @@ export class ContextBuilder {
           fragments = await this.#store.searchBySource(
             "learning_extraction",
             agentId,
-            keyId,
+            groupKeyIds,
             5,
             workspace
           );

--- a/lib/memory/FragmentReader.js
+++ b/lib/memory/FragmentReader.js
@@ -551,21 +551,29 @@ export class FragmentReader {
    *
    * @param {string}      source  - 파편 source 값 (예: "learning_extraction")
    * @param {string}      agentId - 에이전트 ID (RLS 격리용)
-   * @param {string|null} keyId   - null: 마스터(전체), string: 해당 API 키 소유만
-   * @param {number}      limit   - 최대 반환 수 (기본 5)
+   * @param {string|string[]|null} keyId   - null: 마스터(전체), string|string[]: API 키 소유 필터
+   * @param {number}               limit   - 최대 반환 수 (기본 5)
+   * @param {string|null}          workspace
+   * @param {boolean}              includeSuperseded
    * @returns {Promise<Object[]>} 파편 배열
    */
-  async searchBySource(source, agentId, keyId, limit = 5, workspace = null) {
+  async searchBySource(source, agentId, keyId, limit = 5, workspace = null, includeSuperseded = false) {
     let query = `SELECT id, content, topic, type, keywords, importance, source,
                         agent_id, created_at, is_anchor, access_count, accessed_at,
                         context_summary, session_id, workspace,
                         case_id, goal, outcome, phase, resolution_status, assertion_status
                  FROM ${SCHEMA}.fragments
-                 WHERE source = $1 AND (agent_id = $2 OR agent_id = 'default') AND valid_to IS NULL`;
+                 WHERE source = $1 AND (agent_id = $2 OR agent_id = 'default')`;
     const params = [source, agentId || "default"];
-    if (keyId) {
-      params.push(keyId);
-      query += ` AND key_id = $${params.length}`;
+
+    if (!includeSuperseded) {
+      query += " AND valid_to IS NULL";
+    }
+
+    if (keyId !== null && keyId !== undefined) {
+      const keyIds = Array.isArray(keyId) ? keyId : [keyId];
+      params.push(keyIds);
+      query += ` AND key_id = ANY($${params.length}::text[])`;
     }
     if (workspace) {
       params.push(workspace);

--- a/lib/memory/FragmentReader.js
+++ b/lib/memory/FragmentReader.js
@@ -555,33 +555,89 @@ export class FragmentReader {
    * @param {number}               limit   - 최대 반환 수 (기본 5)
    * @param {string|null}          workspace
    * @param {boolean}              includeSuperseded
+   * @param {Object}               filters
    * @returns {Promise<Object[]>} 파편 배열
    */
-  async searchBySource(source, agentId, keyId, limit = 5, workspace = null, includeSuperseded = false) {
-    let query = `SELECT id, content, topic, type, keywords, importance, source,
-                        agent_id, created_at, is_anchor, access_count, accessed_at,
-                        context_summary, session_id, workspace,
-                        case_id, goal, outcome, phase, resolution_status, assertion_status
-                 FROM ${SCHEMA}.fragments
-                 WHERE source = $1 AND (agent_id = $2 OR agent_id = 'default')`;
-    const params = [source, agentId || "default"];
+  async searchBySource(source, agentId, keyId, limit = 5, workspace = null, includeSuperseded = false, filters = {}) {
+    const conditions = ["source = $1", `(agent_id = $2 OR agent_id = 'default')`];
+    const params     = [source, agentId || "default"];
+    let paramIdx     = 3;
 
-    if (!includeSuperseded) {
-      query += " AND valid_to IS NULL";
+    if (filters.type) {
+      conditions.push(`type = $${paramIdx}`);
+      params.push(filters.type);
+      paramIdx++;
     }
-
+    if (filters.topic) {
+      conditions.push(`topic = $${paramIdx}`);
+      params.push(filters.topic);
+      paramIdx++;
+    }
+    if (filters.minImportance) {
+      conditions.push(`importance >= $${paramIdx}`);
+      params.push(filters.minImportance);
+      paramIdx++;
+    }
+    if (filters.isAnchor !== undefined) {
+      conditions.push(`is_anchor = $${paramIdx}`);
+      params.push(filters.isAnchor);
+      paramIdx++;
+    }
+    if (!includeSuperseded) {
+      conditions.push("valid_to IS NULL");
+    }
     if (keyId !== null && keyId !== undefined) {
       const keyIds = Array.isArray(keyId) ? keyId : [keyId];
+      conditions.push(`key_id = ANY($${paramIdx}::text[])`);
       params.push(keyIds);
-      query += ` AND key_id = ANY($${params.length}::text[])`;
+      paramIdx++;
     }
     if (workspace) {
+      conditions.push(`(workspace = $${paramIdx} OR workspace IS NULL)`);
       params.push(workspace);
-      query += ` AND (workspace = $${params.length} OR workspace IS NULL)`;
+      paramIdx++;
     }
-    query += ` ORDER BY importance DESC, created_at DESC LIMIT $${params.length + 1}`;
+    if (filters.timeRange) {
+      if (filters.timeRange.from) {
+        conditions.push(`created_at >= $${paramIdx}`);
+        params.push(filters.timeRange.from);
+        paramIdx++;
+      }
+      if (filters.timeRange.to) {
+        conditions.push(`created_at < $${paramIdx}`);
+        params.push(filters.timeRange.to);
+        paramIdx++;
+      }
+    }
+    if (filters.caseId) {
+      conditions.push(`case_id = $${paramIdx}`);
+      params.push(filters.caseId);
+      paramIdx++;
+    }
+    if (filters.resolutionStatus) {
+      conditions.push(`resolution_status = $${paramIdx}`);
+      params.push(filters.resolutionStatus);
+      paramIdx++;
+    }
+    if (filters.phase) {
+      conditions.push(`phase = $${paramIdx}`);
+      params.push(filters.phase);
+      paramIdx++;
+    }
+
     params.push(limit);
-    const result = await queryWithAgentVector(agentId, query, params);
+
+    const result = await queryWithAgentVector(agentId,
+      `SELECT id, content, topic, type, keywords, importance, source,
+                    agent_id, created_at, is_anchor, access_count, accessed_at,
+                    context_summary, session_id, workspace,
+                    case_id, goal, outcome, phase, resolution_status, assertion_status
+             FROM ${SCHEMA}.fragments
+             WHERE ${conditions.join(" AND ")}
+             ORDER BY importance DESC, created_at DESC
+             LIMIT $${paramIdx}`,
+      params
+    );
     return result.rows || [];
   }
 

--- a/lib/memory/FragmentSearch.js
+++ b/lib/memory/FragmentSearch.js
@@ -482,7 +482,8 @@ export class FragmentSearch {
         agentId,
         keyId,
         options.limit,
-        query.workspace ?? null
+        query.workspace ?? null,
+        options.includeSuperseded
       );
 
       if (options.type) {
@@ -490,6 +491,15 @@ export class FragmentSearch {
       }
       if (options.minImportance) {
         results = results.filter(f => (f.importance || 0) >= options.minImportance);
+      }
+      if (query.caseId) {
+        results = results.filter(f => f.case_id === query.caseId);
+      }
+      if (query.resolutionStatus) {
+        results = results.filter(f => f.resolution_status === query.resolutionStatus);
+      }
+      if (query.phase) {
+        results = results.filter(f => f.phase === query.phase);
       }
     }
 

--- a/lib/memory/FragmentSearch.js
+++ b/lib/memory/FragmentSearch.js
@@ -477,30 +477,26 @@ export class FragmentSearch {
 
     /** source-only 또는 source 보강 fallback */
     if (results.length === 0 && query.source) {
+      const sourceFilters = {
+        ...(options.type ? { type: options.type } : {}),
+        ...(options.topic ? { topic: options.topic } : {}),
+        ...(options.minImportance ? { minImportance: options.minImportance } : {}),
+        ...(query.isAnchor !== undefined ? { isAnchor: query.isAnchor } : {}),
+        ...(timeRange ? { timeRange } : {}),
+        ...(query.caseId ? { caseId: query.caseId } : {}),
+        ...(query.resolutionStatus ? { resolutionStatus: query.resolutionStatus } : {}),
+        ...(query.phase ? { phase: query.phase } : {})
+      };
+
       results = await this.store.searchBySource(
         query.source,
         agentId,
         keyId,
         options.limit,
         query.workspace ?? null,
-        options.includeSuperseded
+        options.includeSuperseded,
+        sourceFilters
       );
-
-      if (options.type) {
-        results = results.filter(f => f.type === options.type);
-      }
-      if (options.minImportance) {
-        results = results.filter(f => (f.importance || 0) >= options.minImportance);
-      }
-      if (query.caseId) {
-        results = results.filter(f => f.case_id === query.caseId);
-      }
-      if (query.resolutionStatus) {
-        results = results.filter(f => f.resolution_status === query.resolutionStatus);
-      }
-      if (query.phase) {
-        results = results.filter(f => f.phase === query.phase);
-      }
     }
 
     /** 추가 ID 기반 조회 (L1에서 찾은 것 중 캐시 미스분) */

--- a/lib/memory/FragmentStore.js
+++ b/lib/memory/FragmentStore.js
@@ -33,8 +33,8 @@ export class FragmentStore {
   }
   searchByTimeRange(from, to, options)                                  { return this.reader.searchByTimeRange(from, to, options); }
   searchAsOf(asOf, agentId, opts, keyId)                               { return this.reader.searchAsOf(asOf, agentId, opts, keyId); }
-  searchBySource(source, agentId, keyId, limit, workspace = null, includeSuperseded = false) {
-    return this.reader.searchBySource(source, agentId, keyId, limit, workspace, includeSuperseded);
+  searchBySource(source, agentId, keyId, limit, workspace = null, includeSuperseded = false, filters = {}) {
+    return this.reader.searchBySource(source, agentId, keyId, limit, workspace, includeSuperseded, filters);
   }
   findCaseIdBySessionTopic(sessionId, topic, keyId)                    { return this.reader.findCaseIdBySessionTopic(sessionId, topic, keyId); }
   findErrorFragmentsBySessionTopic(sessionId, topic, keyId)            { return this.reader.findErrorFragmentsBySessionTopic(sessionId, topic, keyId); }

--- a/lib/memory/FragmentStore.js
+++ b/lib/memory/FragmentStore.js
@@ -33,7 +33,9 @@ export class FragmentStore {
   }
   searchByTimeRange(from, to, options)                                  { return this.reader.searchByTimeRange(from, to, options); }
   searchAsOf(asOf, agentId, opts, keyId)                               { return this.reader.searchAsOf(asOf, agentId, opts, keyId); }
-  searchBySource(source, agentId, keyId, limit, workspace = null)      { return this.reader.searchBySource(source, agentId, keyId, limit, workspace); }
+  searchBySource(source, agentId, keyId, limit, workspace = null, includeSuperseded = false) {
+    return this.reader.searchBySource(source, agentId, keyId, limit, workspace, includeSuperseded);
+  }
   findCaseIdBySessionTopic(sessionId, topic, keyId)                    { return this.reader.findCaseIdBySessionTopic(sessionId, topic, keyId); }
   findErrorFragmentsBySessionTopic(sessionId, topic, keyId)            { return this.reader.findErrorFragmentsBySessionTopic(sessionId, topic, keyId); }
 

--- a/tests/unit/context-builder.test.js
+++ b/tests/unit/context-builder.test.js
@@ -291,7 +291,7 @@ describe("ContextBuilder.build()", () => {
     assert.match(result.injectionText, /fallback learning/);
   });
 
-  it("hardening=false(명시적 레거시 모드)에서는 learning 파편을 보조 섹션으로 주입하지 않는다", async () => {
+  it("hardening=false(명시적 호환 모드)에서는 learning 파편을 주입하지 않는다", async () => {
     storeMock.searchBySource = mock.fn(async () => [
       frag("learn-default", "fact", "default learning content", { source: "learning_extraction" })
     ]);

--- a/tests/unit/context-builder.test.js
+++ b/tests/unit/context-builder.test.js
@@ -289,12 +289,18 @@ describe("ContextBuilder.build()", () => {
     });
 
     assert.equal(storeMock.searchBySource.mock.callCount(), 1);
-    assert.deepEqual(storeMock.searchBySource.mock.calls[0].arguments.slice(0, 5), [
+    assert.deepEqual(storeMock.searchBySource.mock.calls[0].arguments, [
       "learning_extraction",
       "default",
       ["key-1", "key-2"],
       5,
-      null
+      null,
+      false,
+      {
+        caseId          : "case-123",
+        resolutionStatus: "open",
+        phase           : "debugging"
+      }
     ]);
     assert.equal(storeMock.searchBySource.mock.calls[0].arguments[5], false);
     assert.deepEqual(storeMock.searchBySource.mock.calls[0].arguments[6], {

--- a/tests/unit/context-builder.test.js
+++ b/tests/unit/context-builder.test.js
@@ -302,12 +302,6 @@ describe("ContextBuilder.build()", () => {
         phase           : "debugging"
       }
     ]);
-    assert.equal(storeMock.searchBySource.mock.calls[0].arguments[5], false);
-    assert.deepEqual(storeMock.searchBySource.mock.calls[0].arguments[6], {
-      caseId          : "case-123",
-      resolutionStatus: "open",
-      phase           : "debugging"
-    });
     assert.ok(result.fragments.some(f => f.id === "learn-fallback-1"));
     assert.match(result.injectionText, /fallback learning/);
   });

--- a/tests/unit/context-builder.test.js
+++ b/tests/unit/context-builder.test.js
@@ -296,6 +296,12 @@ describe("ContextBuilder.build()", () => {
       5,
       null
     ]);
+    assert.equal(storeMock.searchBySource.mock.calls[0].arguments[5], false);
+    assert.deepEqual(storeMock.searchBySource.mock.calls[0].arguments[6], {
+      caseId          : "case-123",
+      resolutionStatus: "open",
+      phase           : "debugging"
+    });
     assert.ok(result.fragments.some(f => f.id === "learn-fallback-1"));
     assert.match(result.injectionText, /fallback learning/);
   });

--- a/tests/unit/context-builder.test.js
+++ b/tests/unit/context-builder.test.js
@@ -283,10 +283,19 @@ describe("ContextBuilder.build()", () => {
       contextText     : "현재 user 질의",
       caseId          : "case-123",
       resolutionStatus: "open",
-      phase           : "debugging"
+      phase           : "debugging",
+      _keyId          : "key-1",
+      _groupKeyIds    : ["key-1", "key-2"]
     });
 
     assert.equal(storeMock.searchBySource.mock.callCount(), 1);
+    assert.deepEqual(storeMock.searchBySource.mock.calls[0].arguments.slice(0, 5), [
+      "learning_extraction",
+      "default",
+      ["key-1", "key-2"],
+      5,
+      null
+    ]);
     assert.ok(result.fragments.some(f => f.id === "learn-fallback-1"));
     assert.match(result.injectionText, /fallback learning/);
   });

--- a/tests/unit/fragment-search-source-filter.test.js
+++ b/tests/unit/fragment-search-source-filter.test.js
@@ -28,6 +28,32 @@ describe("FragmentSearch source filter", () => {
     assert.equal(results[0].id, "learn-1");
   });
 
+  it("source fallback은 group key 배열과 includeSuperseded를 그대로 전달한다", async () => {
+    const search = new FragmentSearch();
+    search.store = {
+      searchByKeywords: mock.fn(async () => []),
+      searchByTopic   : mock.fn(async () => []),
+      searchBySource  : mock.fn(async () => [
+        { id: "learn-1", content: "learning", source: "learning_extraction", importance: 0.8 }
+      ]),
+      getByIds        : mock.fn(async () => [])
+    };
+
+    await search._searchL2(
+      { source: "learning_extraction", includeSuperseded: true, workspace: "maker" },
+      [],
+      "default",
+      ["key-a", "key-b"],
+      null
+    );
+
+    assert.equal(search.store.searchBySource.mock.callCount(), 1);
+    assert.deepEqual(
+      search.store.searchBySource.mock.calls[0].arguments,
+      ["learning_extraction", "default", ["key-a", "key-b"], 30, "maker", true]
+    );
+  });
+
   it("_executeSearch는 HotCache/L1 경로에서도 source 후처리 필터를 적용한다", async () => {
     const search = new FragmentSearch();
     search._searchL1 = mock.fn(async () => ({ ids: ["keep", "drop"], isFallback: false }));

--- a/tests/unit/fragment-search-source-filter.test.js
+++ b/tests/unit/fragment-search-source-filter.test.js
@@ -1,6 +1,7 @@
 import { describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
 
+import { FragmentReader } from "../../lib/memory/FragmentReader.js";
 import { FragmentSearch } from "../../lib/memory/FragmentSearch.js";
 
 describe("FragmentSearch source filter", () => {
@@ -50,7 +51,65 @@ describe("FragmentSearch source filter", () => {
     assert.equal(search.store.searchBySource.mock.callCount(), 1);
     assert.deepEqual(
       search.store.searchBySource.mock.calls[0].arguments,
-      ["learning_extraction", "default", ["key-a", "key-b"], 30, "maker", true]
+      [
+        "learning_extraction",
+        "default",
+        ["key-a", "key-b"],
+        30,
+        "maker",
+        true,
+        { minImportance: 0.1 }
+      ]
+    );
+  });
+
+  it("source fallback은 narrative 필터를 searchBySource SQL 경로로 전달한다", async () => {
+    const search = new FragmentSearch();
+    search.store = {
+      searchByKeywords: mock.fn(async () => []),
+      searchByTopic   : mock.fn(async () => []),
+      searchBySource  : mock.fn(async () => [
+        { id: "learn-1", content: "learning", source: "learning_extraction", importance: 0.8 }
+      ]),
+      getByIds        : mock.fn(async () => [])
+    };
+
+    const timeRange = { from: "2026-04-01T00:00:00.000Z", to: "2026-04-20T00:00:00.000Z" };
+
+    await search._searchL2(
+      {
+        source          : "learning_extraction",
+        workspace       : "maker",
+        caseId          : "case-123",
+        resolutionStatus: "open",
+        phase           : "debugging",
+        type            : "fact",
+        minImportance   : 0.4
+      },
+      [],
+      "default",
+      ["key-a", "key-b"],
+      timeRange
+    );
+
+    assert.deepEqual(
+      search.store.searchBySource.mock.calls[0].arguments,
+      [
+        "learning_extraction",
+        "default",
+        ["key-a", "key-b"],
+        30,
+        "maker",
+        false,
+        {
+          type            : "fact",
+          minImportance   : 0.4,
+          timeRange,
+          caseId          : "case-123",
+          resolutionStatus: "open",
+          phase           : "debugging"
+        }
+      ]
     );
   });
 
@@ -81,5 +140,14 @@ describe("FragmentSearch source filter", () => {
     );
 
     assert.deepEqual(result.combined.map(f => f.id), ["keep"]);
+  });
+});
+
+describe("searchBySource SQL filters", () => {
+  it("searchBySource는 source fallback용 narrative 필터를 SQL로 적용한다", () => {
+    const src = FragmentReader.prototype.searchBySource.toString();
+    assert.ok(src.includes("case_id = $"), "searchBySource should filter case_id in SQL");
+    assert.ok(src.includes("resolution_status = $"), "searchBySource should filter resolution_status in SQL");
+    assert.ok(src.includes("phase = $"), "searchBySource should filter phase in SQL");
   });
 });

--- a/tests/unit/recall-key-id-visibility.test.js
+++ b/tests/unit/recall-key-id-visibility.test.js
@@ -48,6 +48,16 @@ describe("searchBySemantic — SELECT f.key_id 포함", () => {
   });
 });
 
+describe("searchBySource — key_id 배열 필터 포함", () => {
+  it("searchBySource가 key_id = ANY 패턴을 포함하고 있어야 한다", () => {
+    const src = FragmentReader.prototype.searchBySource.toString();
+    assert.ok(
+      src.includes("key_id = ANY("),
+      "searchBySource에 key_id = ANY( 패턴이 없음"
+    );
+  });
+});
+
 /** ── 2. master 케이스: keyId=null 시 key_id 조건 미포함 ───────────────── */
 
 describe("master 케이스 — keyId null 시 WHERE key_id 조건 없어야 함", () => {

--- a/tests/unit/recall-valid-to-filter.test.js
+++ b/tests/unit/recall-valid-to-filter.test.js
@@ -29,4 +29,10 @@ describe("recall valid_to filter", () => {
     const src = FragmentReader.prototype.searchByKeywords.toString();
     assert.ok(src.includes("includeSuperseded"), "searchByKeywords should check options.includeSuperseded");
   });
+
+  it("searchBySource는 includeSuperseded=false일 때만 valid_to 필터를 적용한다", () => {
+    const src = FragmentReader.prototype.searchBySource.toString();
+    assert.ok(src.includes("includeSuperseded"), "searchBySource should accept includeSuperseded");
+    assert.ok(src.includes("valid_to IS NULL"), "searchBySource should conditionally filter valid_to");
+  });
 });


### PR DESCRIPTION
## 목표

- `context` hardening과 auxiliary planning을 기본 경로로 전환하고, source fallback recall이 일반 recall 경로와 같은 필터 semantics를 유지하도록 정리합니다.

## 해결한 내용

- `config/memory.js`: `hardeningEnabled=true`, `llmPlannerEnabled=true` 기본값으로 바꿔 hardening 경로를 기본 rollout으로 전환했습니다.
- `lib/memory/FragmentReader.js`, `lib/memory/FragmentStore.js`, `lib/memory/FragmentSearch.js`: source fallback recall이 `key_id` 배열을 `ANY(...)`로 처리하고, `includeSuperseded`, `type`, `minImportance`, `caseId`, `resolutionStatus`, `phase`, `timeRange`를 `LIMIT` 전에 SQL에서 반영하도록 맞췄습니다.
- `lib/memory/ContextBuilder.js`: auxiliary learning fallback도 `caseId`, `resolutionStatus`, `phase`를 `searchBySource()` SQL 필터로 넘겨, source 상위 5건만 가져온 뒤 메모리 후필터링하던 누락 문제를 제거했습니다.
- `tests/unit/context-builder.test.js`, `tests/unit/fragment-search-source-filter.test.js`, `tests/unit/recall-valid-to-filter.test.js`, `tests/unit/recall-key-id-visibility.test.js`: hardening 기본 경로와 source fallback 회귀를 고정하는 단위 테스트를 보강했습니다.

## 동기화 메모

- 닫힌 `#1`의 후속 구현 PR이며, 리뷰에서 지적된 group key/source fallback 회귀와 auxiliary fallback pre-`LIMIT` 필터 누락까지 현재 head 기준으로 반영했습니다.

## 검증

- `node --experimental-test-module-mocks --test tests/unit/context-builder.test.js tests/unit/auxiliary-section-planner.test.js tests/unit/fragment-search-source-filter.test.js tests/unit/memory-manager-recall-source-filter.test.js tests/unit/recall-valid-to-filter.test.js tests/unit/recall-key-id-visibility.test.js`
- `npx eslint lib/memory/ContextBuilder.js tests/unit/context-builder.test.js`