### PR TITLE
feat(context): add procedure auxiliary memory

### DIFF
--- a/lib/memory/AuxiliarySectionPlanner.js
+++ b/lib/memory/AuxiliarySectionPlanner.js
@@ -44,7 +44,7 @@ export const AUXILIARY_SECTION_CATALOG = {
 const DEBUG_OR_ERROR_RE =
   /(error|bug|fail|failure|debug|debugging|trace|exception|incident|issue|에러|버그|실패|디버그|예외|문제)/i;
 const PROCEDURE_RE =
-  /(how|step|steps|procedure|runbook|workflow|deploy|deployment|migrate|migration|rollback|recover|recovery|reproduce|reproduction|setup|install|configure|fix|restore|방법|절차|단계|실행|배포|마이그레이션|롤백|복구|재현|설치|설정)/i;
+  /(\b(how|step|steps|procedure|runbook|workflow|deploy|deployment|migrate|migration|rollback|recover|recovery|reproduce|reproduction|setup|install|configure|fix|restore)\b|방법|절차|단계|실행|배포|마이그레이션|롤백|복구|재현|설치|설정)/i;
 const DECISION_RE =
   /(decision|tradeoff|design|architecture|approach|why|choose|choice|선택|결정|설계|구조|방식|이유)/i;
 const HISTORY_RE =

--- a/lib/memory/AuxiliarySectionPlanner.js
+++ b/lib/memory/AuxiliarySectionPlanner.js
@@ -23,6 +23,10 @@ export const AUXILIARY_SECTION_CATALOG = {
     title      : "ERROR PLAYBOOK",
     description: "Past error fragments and fix clues relevant to debugging, failures, or open issues."
   },
+  procedure_memory: {
+    title      : "PROCEDURE MEMORY",
+    description: "Past procedures and runbooks relevant to execution, deployment, recovery, or step-by-step work."
+  },
   decision_memory: {
     title      : "DECISION MEMORY",
     description: "Past architectural or product decisions relevant to planning, tradeoffs, or why-questions."
@@ -39,6 +43,8 @@ export const AUXILIARY_SECTION_CATALOG = {
 
 const DEBUG_OR_ERROR_RE =
   /(error|bug|fail|failure|debug|debugging|trace|exception|incident|issue|에러|버그|실패|디버그|예외|문제)/i;
+const PROCEDURE_RE =
+  /(how|step|steps|procedure|runbook|workflow|deploy|deployment|migrate|migration|rollback|recover|recovery|reproduce|reproduction|setup|install|configure|fix|restore|방법|절차|단계|실행|배포|마이그레이션|롤백|복구|재현|설치|설정)/i;
 const DECISION_RE =
   /(decision|tradeoff|design|architecture|approach|why|choose|choice|선택|결정|설계|구조|방식|이유)/i;
 const HISTORY_RE =
@@ -63,15 +69,15 @@ export function buildHeuristicAuxiliaryPlan({
   resolutionStatus = null,
   phase = null,
   maxSections = MEMORY_CONFIG.contextInjection?.maxAuxiliarySections || 2
-} = {}) {
+  } = {}) {
   const query = typeof contextText === "string" ? contextText.trim() : "";
   const picks = [];
 
-  if (query) {
-    picks.push("learning_memory");
-  }
   if (phase === "debugging" || resolutionStatus === "open" || DEBUG_OR_ERROR_RE.test(query)) {
     picks.push("error_playbook");
+  }
+  if (phase === "debugging" || PROCEDURE_RE.test(query)) {
+    picks.push("procedure_memory");
   }
   if (phase === "planning" || DECISION_RE.test(query)) {
     picks.push("decision_memory");
@@ -81,6 +87,9 @@ export function buildHeuristicAuxiliaryPlan({
   }
   if (resolutionStatus === "open" || OPEN_QUESTION_RE.test(query)) {
     picks.push("open_questions_memory");
+  }
+  if (query) {
+    picks.push("learning_memory");
   }
 
   return {

--- a/lib/memory/ContextBuilder.js
+++ b/lib/memory/ContextBuilder.js
@@ -237,6 +237,22 @@ export class ContextBuilder {
         };
       }
 
+      case "procedure_memory": {
+        const result = await this.#recall({
+          ...baseRecallParams,
+          type        : "procedure",
+          depth       : "tool-level",
+          includeLinks: false
+        });
+        const fragments = capFragmentsToBudget(result.fragments || [], auxiliaryCharBudget);
+        if (fragments.length === 0) return null;
+        return {
+          key      : sectionKey,
+          title    : AUXILIARY_SECTION_CATALOG[sectionKey].title,
+          fragments
+        };
+      }
+
       case "decision_memory": {
         const result = await this.#recall({
           ...baseRecallParams,
@@ -635,6 +651,7 @@ export class ContextBuilder {
       }
       const learningFragments = auxiliarySections.find(section => section.key === "learning_memory")?.fragments || [];
       const errorPlaybook = auxiliarySections.find(section => section.key === "error_playbook")?.fragments || [];
+      const procedureMemory = auxiliarySections.find(section => section.key === "procedure_memory")?.fragments || [];
       const decisionMemory = auxiliarySections.find(section => section.key === "decision_memory")?.fragments || [];
       const openQuestionsMemory = auxiliarySections.find(section => section.key === "open_questions_memory")?.fragments || [];
       const caseMemory = auxiliarySections.find(section => section.key === "case_memory")?.cases || [];
@@ -678,6 +695,7 @@ export class ContextBuilder {
         },
         auxiliary       : {
           errorPlaybook,
+          procedureMemory,
           decisionMemory,
           openQuestionsMemory,
           caseMemory

--- a/tests/unit/auxiliary-section-planner.test.js
+++ b/tests/unit/auxiliary-section-planner.test.js
@@ -17,6 +17,25 @@ describe("AuxiliarySectionPlanner", () => {
     assert.ok(result.sections.includes("error_playbook"));
   });
 
+  it("heuristic planner가 절차/배포 질의에서 procedure_memory를 고른다", () => {
+    const result = buildHeuristicAuxiliaryPlan({
+      contextText: "배포 절차와 복구 단계가 필요하다",
+      maxSections: 3
+    });
+
+    assert.ok(result.sections.includes("procedure_memory"));
+  });
+
+  it("heuristic planner는 maxSections=2일 때 learning보다 error/procedure를 우선한다", () => {
+    const result = buildHeuristicAuxiliaryPlan({
+      contextText: "에러 복구 절차를 알려줘",
+      phase      : "debugging",
+      maxSections: 2
+    });
+
+    assert.deepEqual(result.sections, ["error_playbook", "procedure_memory"]);
+  });
+
   it("LLM planner 결과를 sanitize하여 허용된 섹션만 유지한다", async () => {
     const llmJsonFn = mock.fn(async () => ({
       sections : ["decision_memory", "invalid_section", "case_memory"],
@@ -50,6 +69,7 @@ describe("AuxiliarySectionPlanner", () => {
     });
 
     assert.equal(result.source, "heuristic");
+    assert.ok(result.sections.includes("error_playbook"));
     assert.ok(result.sections.includes("case_memory"));
     assert.ok(result.sections.includes("open_questions_memory"));
   });

--- a/tests/unit/auxiliary-section-planner.test.js
+++ b/tests/unit/auxiliary-section-planner.test.js
@@ -26,6 +26,15 @@ describe("AuxiliarySectionPlanner", () => {
     assert.ok(result.sections.includes("procedure_memory"));
   });
 
+  it("heuristic planner는 show 같은 부분 문자열로 procedure_memory를 고르지 않는다", () => {
+    const result = buildHeuristicAuxiliaryPlan({
+      contextText: "show me recent errors",
+      maxSections: 3
+    });
+
+    assert.ok(!result.sections.includes("procedure_memory"));
+  });
+
   it("heuristic planner는 maxSections=2일 때 learning보다 error/procedure를 우선한다", () => {
     const result = buildHeuristicAuxiliaryPlan({
       contextText: "에러 복구 절차를 알려줘",

--- a/tests/unit/context-builder.test.js
+++ b/tests/unit/context-builder.test.js
@@ -506,6 +506,46 @@ describe("ContextBuilder.build()", () => {
     assert.equal(structuredResult.auxiliary.decisionMemory.length, 1);
   });
 
+  it("planner가 선택한 procedure 보조 섹션을 추가로 붙인다", async () => {
+    recallMock = mock.fn(async (params) => {
+      if (params.topic === "session_reflect") return { fragments: [] };
+      if (params.type === "procedure" && params.text) {
+        return { fragments: [frag("proc-aux-1", "procedure", "targeted procedure memory")] };
+      }
+      return {
+        fragments: [
+          frag(`${params.type}-1`, params.type, `${params.type} content 1`),
+          frag(`${params.type}-2`, params.type, `${params.type} content 2`),
+        ]
+      };
+    });
+    auxiliaryPlannerMock = mock.fn(async () => ({
+      sections: ["procedure_memory"]
+    }));
+    builder = new ContextBuilder({
+      recall          : recallMock,
+      store           : storeMock,
+      index           : indexMock,
+      getPool         : () => null,
+      hardeningEnabled: true,
+      auxiliaryPlanner: auxiliaryPlannerMock,
+    });
+
+    const flatResult = await builder.build({
+      contextText: "배포 절차와 복구 순서를 보고 싶다"
+    });
+
+    assert.match(flatResult.injectionText, /\[PROCEDURE MEMORY\]/);
+    assert.match(flatResult.injectionText, /targeted procedure memory/);
+
+    const structuredResult = await builder.build({
+      contextText: "배포 절차와 복구 순서를 보고 싶다",
+      structured : true
+    });
+    assert.equal(structuredResult.auxiliary.procedureMemory.length, 1);
+    assert.equal(structuredResult.auxiliary.procedureMemory[0].id, "proc-aux-1");
+  });
+
   it("파편이 비어 있으면 _memento_hint에 empty_context 포함", async () => {
     recallMock = mock.fn(async () => ({ fragments: [] }));
     builder    = new ContextBuilder({


### PR DESCRIPTION
## 목표

- hardening auxiliary memory에 `PROCEDURE MEMORY`를 추가합니다.
- `maxAuxiliarySections=2` 환경에서 heuristic fallback이 `LEARNING MEMORY`를 먼저 채워 더 중요한 절차/에러 보조 섹션을 밀어내지 않도록 우선순위를 조정합니다.

## 해결한 내용

- `lib/memory/AuxiliarySectionPlanner.js`
  - `PROCEDURE MEMORY` 카탈로그 항목을 추가했습니다.
  - 절차/배포/복구/재현 관련 질의를 감지하는 heuristic를 추가했습니다.
  - heuristic fallback 순서를 조정해 `error_playbook`, `procedure_memory`, `decision_memory`, `case_memory`, `open_questions_memory`를 먼저 평가하고 `learning_memory`는 마지막 fallback으로 밀었습니다.
- `lib/memory/ContextBuilder.js`
  - `procedure_memory` 로더를 추가해 `type=procedure`, `depth=tool-level` recall 결과를 보조 섹션으로 붙이도록 했습니다.
  - structured context 응답의 `auxiliary.procedureMemory` 필드를 추가했습니다.
- `tests/unit/auxiliary-section-planner.test.js`
  - procedure 질의 선택과 `maxSections=2` 우선순위 회귀 테스트를 추가했습니다.
- `tests/unit/context-builder.test.js`
  - `PROCEDURE MEMORY`가 flat injectionText와 structured auxiliary 응답에 모두 반영되는지 검증하는 테스트를 추가했습니다.

## 검증

- `node --experimental-test-module-mocks --test tests/unit/auxiliary-section-planner.test.js tests/unit/context-builder.test.js`
- `npx eslint lib/memory/AuxiliarySectionPlanner.js lib/memory/ContextBuilder.js tests/unit/auxiliary-section-planner.test.js tests/unit/context-builder.test.js`
- `git diff --check`