### PR TITLE
codex-cli fallback provider 설정 전달과 실행 contract 정리

### DIFF
--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -1054,12 +1054,12 @@ LLM_PRIMARY=gemini-cli
 [gemini-cli] -> fail -> [anthropic] -> fail -> [codex-cli] -> fail -> [copilot-cli] -> ...
 ```
 
-**codex-cli provider** (`lib/llm/providers/codex-cli.js`):
-1. `runCodexCLI(prompt, outputFile)` -- runs `codex exec --full-auto --skip-git-repo-check -o FILE`
+**codex-cli provider** (`lib/llm/providers/CodexCliProvider.js`):
+1. `runCodexCLI(stdinContent, prompt, options)` -- runs `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE`
 2. Reads output file -> JSON parse -> return response
 - Authenticates via `OPENAI_API_KEY` or Codex CLI's own configuration file
 
-**copilot-cli provider** (`lib/llm/providers/copilot-cli.js`):
+**copilot-cli provider** (`lib/llm/providers/CopilotCliProvider.js`):
 - Calls GitHub Copilot CLI (`gh copilot suggest`) as a wrapper
 - Uses `extractJsonBlock()` utility to strip trailing statistics/banner text before JSON extraction
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1057,12 +1057,12 @@ LLM_PRIMARY=gemini-cli
 [gemini-cli] → 실패 → [anthropic] → 실패 → [codex-cli] → 실패 → [copilot-cli] → ...
 ```
 
-**codex-cli provider** (`lib/llm/providers/codex-cli.js`):
-1. `runCodexCLI(prompt, outputFile)` — `codex exec --full-auto --skip-git-repo-check -o FILE` 실행
+**codex-cli provider** (`lib/llm/providers/CodexCliProvider.js`):
+1. `runCodexCLI(stdinContent, prompt, options)` — `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE` 실행
 2. 결과 파일 읽기 → JSON 파싱 → 응답 반환
 - 환경변수 `OPENAI_API_KEY` 또는 Codex CLI 자체 설정 파일로 인증
 
-**copilot-cli provider** (`lib/llm/providers/copilot-cli.js`):
+**copilot-cli provider** (`lib/llm/providers/CopilotCliProvider.js`):
 - GitHub Copilot CLI(`gh copilot suggest`)를 래퍼로 호출
 - `extractJsonBlock()` 유틸리티로 응답 말미의 통계/배너 텍스트 제거 후 JSON 추출
 

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -72,7 +72,7 @@ The `api_keys.symbolic_hard_gate` column (migration-033) enables per-key hard ga
 
 #### LLM Provider Fallback Chain (v2.8.0)
 
-Automatic fallback to 12 providers beyond Gemini CLI. Existing behavior is fully preserved with default settings.
+Automatic fallback to 14 providers beyond Gemini CLI. Existing behavior is fully preserved with default settings.
 
 ##### Basic Configuration
 
@@ -103,9 +103,9 @@ When REDIS_ENABLED=true, state is stored in Redis; otherwise in-memory.
 
 gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**
 
-**codex-cli**: Executes `codex exec --full-auto --skip-git-repo-check -o FILE`. Authenticates via `OPENAI_API_KEY` or Codex CLI config file. Specify in `LLM_FALLBACKS` as:
+**codex-cli**: Executes `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE`. Authenticates via `OPENAI_API_KEY` or the Codex CLI config file. Specify in `LLM_FALLBACKS` as:
 ```json
-[{"provider": "codex-cli"}]
+[{"provider": "codex-cli", "model": "gpt-5.3-codex-spark"}]
 ```
 
 **copilot-cli**: Wraps GitHub Copilot CLI (`gh copilot suggest`). Requires `gh` CLI and a Copilot subscription:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,7 +72,7 @@
 
 #### LLM Provider Fallback Chain (v2.8.0)
 
-Gemini CLI 외 12개 provider로 자동 fallback 가능. 기본값에서 기존 동작 완전 보존.
+Gemini CLI 외 14개 provider로 자동 fallback 가능. 기본값에서 기존 동작 완전 보존.
 
 ##### 기본 설정
 
@@ -103,9 +103,9 @@ REDIS_ENABLED=true면 Redis에 상태 저장, 아니면 in-memory.
 
 gemini-cli, anthropic, openai, google-gemini-api, groq, openrouter, xai, ollama, vllm, deepseek, mistral, cohere, zai, **codex-cli**, **copilot-cli**
 
-**codex-cli**: `codex exec --full-auto --skip-git-repo-check -o FILE` 명령을 실행한다. `OPENAI_API_KEY` 또는 Codex CLI 설정 파일로 인증한다. `LLM_FALLBACKS`에 아래와 같이 지정한다:
+**codex-cli**: `codex exec --skip-git-repo-check --sandbox read-only --output-last-message FILE` 명령을 실행한다. `OPENAI_API_KEY` 또는 Codex CLI 설정 파일로 인증한다. `LLM_FALLBACKS`에 아래와 같이 지정한다:
 ```json
-[{"provider": "codex-cli"}]
+[{"provider": "codex-cli", "model": "gpt-5.3-codex-spark"}]
 ```
 
 **copilot-cli**: GitHub Copilot CLI(`gh copilot suggest`)를 래퍼로 호출한다. `gh` CLI와 Copilot 구독이 필요하다:

--- a/docs/operations/llm-providers.md
+++ b/docs/operations/llm-providers.md
@@ -5,7 +5,7 @@
 
 ## 개요
 
-memento-mcp는 내부 LLM 호출(AutoReflect, MorphemeIndex, ConsolidatorGC, ContradictionDetector, MemoryEvaluator)에 13개 provider fallback chain을 지원한다. 기본값은 Gemini CLI 단독 사용으로 기존 동작 완전 보존.
+memento-mcp는 내부 LLM 호출(AutoReflect, MorphemeIndex, ConsolidatorGC, ContradictionDetector, MemoryEvaluator)에 15개 provider fallback chain을 지원한다. 기본값은 Gemini CLI 단독 사용으로 기존 동작 완전 보존.
 
 ## 활성화
 
@@ -23,18 +23,21 @@ Gemini CLI만 사용. 실패 시 caller가 graceful degradation (AutoReflect ski
 ```bash
 LLM_PRIMARY=gemini-cli
 LLM_FALLBACKS='[
+  {"provider":"codex-cli","model":"gpt-5.3-codex-spark","timeoutMs":120000},
   {"provider":"anthropic","apiKey":"sk-ant-...","model":"claude-opus-4-6"},
   {"provider":"openai","apiKey":"sk-...","model":"gpt-4o-mini"}
 ]'
 ```
 
-Gemini CLI 실패 시 anthropic → openai 순차 시도.
+Gemini CLI 실패 시 codex-cli → anthropic → openai 순차 시도.
 
 ## Provider별 필수 필드
 
 | Provider | apiKey | model | baseUrl | 기본 baseUrl |
 |----------|--------|-------|---------|-------------|
 | gemini-cli | - | - | - | (CLI 바이너리) |
+| codex-cli | - | 선택 | - | (CLI 바이너리 + Codex 인증) |
+| copilot-cli | - | - | - | (CLI 바이너리 + GitHub Copilot 인증) |
 | anthropic | 필수 | 필수 | 선택 | https://api.anthropic.com/v1 |
 | openai | 필수 | 필수 | 선택 | https://api.openai.com/v1 |
 | google-gemini-api | 필수 | 필수 | 선택 | https://generativelanguage.googleapis.com/v1beta |

--- a/lib/codex.js
+++ b/lib/codex.js
@@ -4,18 +4,6 @@
  * 작성자: 최진호
  * 작성일: 2026-04-18
  *
- * 정찰 결과 요약 (2026-04-18):
- *   - 바이너리: /home/nirna/.nvm/versions/node/v24.13.0/bin/codex (v0.121.0)
- *   - 핵심 플래그: codex exec --skip-git-repo-check --full-auto -o FILE [PROMPT]
- *     · --full-auto  : --sandbox workspace-write (자동 실행, 확인 없음)
- *     · --skip-git-repo-check : Git 저장소 외부에서도 실행 가능
- *     · -o FILE      : 에이전트 마지막 메시지를 파일로 기록 (파싱 타겟)
- *     · --json       : NDJSON 스트리밍 (파싱 복잡 — 사용 않음)
- *   - 테스트 호출 결과:
- *     · prompt: 'Return ONLY valid JSON...: {"status":"ok","items":["a","b"]}'
- *     · -o FILE 기록 내용: {"status":"ok","items":["a","b"]} (JSON 직접 파싱 가능)
- *   - stdin 지원: 컨텍스트를 stdin으로 주입하고 prompt 인자로 지시 분리 가능
- *
  * public API:
  *   _rawIsCodexCLIAvailable()  — CLI 바이너리 존재 여부 (CodexCliProvider 전용)
  *   isCodexCLIAvailable()      — LLM chain 가용성 위임 (llm/index.js)
@@ -81,8 +69,8 @@ export async function isCodexCLIAvailable() {
  * Codex CLI를 비대화형(exec) 모드로 호출하여 에이전트 최종 답변을 반환한다.
  *
  * 구현 전략:
- *   - `-o FILE` 플래그로 마지막 메시지만 임시 파일에 기록
- *   - `--full-auto` + `--skip-git-repo-check` 로 무인 실행
+ *   - `--output-last-message FILE` 플래그로 마지막 메시지만 임시 파일에 기록
+ *   - `--sandbox read-only` + `--skip-git-repo-check` 로 보수적 실행
  *   - 임시 파일은 try/finally 블록에서 반드시 삭제
  *   - stdinContent 제공 시 stdin으로 주입 (긴 컨텍스트 분리)
  *
@@ -100,27 +88,28 @@ export async function runCodexCLI(stdinContent, prompt, options = {}) {
   const args = [
     "exec",
     "--skip-git-repo-check",
-    "--full-auto",
-    "-o", outFile
+    "--sandbox", "read-only",
+    "--output-last-message", outFile
   ];
 
   if (options.model) {
-    args.push("-m", options.model);
+    args.push("--model", options.model);
   }
 
   args.push(prompt);
 
   return new Promise((resolve, reject) => {
     const proc = spawn("codex", args, {
-      env:   { ...process.env },
+      env:   { ...process.env, NO_COLOR: "1" },
       stdio: ["pipe", "pipe", "pipe"]
     });
 
+    let   stdout  = "";
     let   stderr  = "";
     let   settled = false;
 
     const cleanup = () => {
-      try { fs.unlinkSync(outFile); } catch (_) {}
+      try { fs.unlinkSync(outFile); } catch (_) { /* temp output already removed */ }
     };
 
     const timer = setTimeout(() => {
@@ -132,6 +121,7 @@ export async function runCodexCLI(stdinContent, prompt, options = {}) {
       }
     }, timeoutMs);
 
+    proc.stdout.on("data", (data) => { stdout += data.toString(); });
     proc.stderr.on("data", (data) => { stderr += data.toString(); });
 
     proc.on("close", (code) => {
@@ -141,7 +131,8 @@ export async function runCodexCLI(stdinContent, prompt, options = {}) {
 
       if (code !== 0) {
         cleanup();
-        reject(new Error(`Codex CLI exited with code ${code}: ${stderr.trim()}`));
+        const detail = (stderr || stdout).trim().slice(0, 1000);
+        reject(new Error(`Codex CLI exited with code ${code}: ${detail}`));
         return;
       }
 

--- a/lib/llm/providers/CodexCliProvider.js
+++ b/lib/llm/providers/CodexCliProvider.js
@@ -58,15 +58,16 @@ export class CodexCliProvider extends LlmProvider {
       throw new Error("codex-cli: circuit breaker open");
     }
 
-    /** CLI는 system role을 별도로 받지 않으므로 prompt 앞에 prepend하여 동등 효과 달성 */
-    const finalPrompt = options.systemPrompt
-      ? `${options.systemPrompt}\n\n${prompt}`
-      : prompt;
+    const finalPrompt = [
+      options.systemPrompt,
+      "Return one valid JSON value only. Do not wrap it in markdown fences. Do not add commentary before or after the JSON.",
+      prompt
+    ].filter(Boolean).join("\n\n");
 
     try {
       const raw    = await runCodexCLI("", finalPrompt, {
-        timeoutMs: options.timeoutMs || 120_000,
-        model    : options.model
+        timeoutMs: options.timeoutMs ?? this.config.timeoutMs ?? 120_000,
+        model    : options.model ?? this.config.model
       });
       const result = parseJsonResponse(raw);
       await this.recordSuccess();

--- a/lib/llm/registry.js
+++ b/lib/llm/registry.js
@@ -65,9 +65,12 @@ export function createProvider(config) {
   const Cls = PROVIDER_CLASSES[name];
   if (!Cls) return null;
 
-  /** CLI provider는 API 키/URL 없이 바이너리만 사용 */
+  /** CLI provider는 API 키/URL 없이 로컬 바이너리 + 선택 model/timeout만 사용 */
   if (name === "gemini-cli" || name === "codex-cli" || name === "copilot-cli") {
-    return new Cls({});
+    return new Cls({
+      model    : typeof config === "object" ? config.model ?? null : null,
+      timeoutMs: typeof config === "object" ? config.timeoutMs ?? null : null
+    });
   }
 
   return new Cls({

--- a/tests/unit/codex-cli-provider.test.js
+++ b/tests/unit/codex-cli-provider.test.js
@@ -1,230 +1,118 @@
 /**
  * Unit tests: CodexCliProvider
  *
- * 실제 Codex CLI 호출 0건 — runCodexCLI와 _rawIsCodexCLIAvailable을 mock으로 교체.
- * circuit breaker 상태는 테스트마다 recordSuccess로 초기화하여 격리한다.
- *
- * 작성자: 최진호
- * 작성일: 2026-04-18
+ * 실제 codex 바이너리 호출 0건 — lib/codex.js를 mock.module로 차단한다.
  */
 
-import { describe, it, before, afterEach } from "node:test";
-import assert                               from "node:assert/strict";
+import { beforeEach, describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
 
-// ---------------------------------------------------------------------------
-// module-level mock 주입: node:test는 jest.mock 같은 자동 호이스팅이 없으므로
-// 테스트 내에서 동적으로 교체할 수 있도록 wrapper를 준비한다.
-// ---------------------------------------------------------------------------
+const mockRunCodexCLI   = mock.fn();
+const mockRawIsCodexCli = mock.fn();
 
-import * as codexModule from "../../lib/codex.js";
-
-let _isAvailableImpl = async () => true;
-let _runCodexImpl    = async () => '{"result":"ok"}';
-
-/** mock shim: _rawIsCodexCLIAvailable 교체 */
-function mockAvailable(impl) { _isAvailableImpl = impl; }
-/** mock shim: runCodexCLI 교체 */
-function mockRunCodex(impl)  { _runCodexImpl    = impl; }
-/** 기본값 복구 */
-function resetMocks() {
-  _isAvailableImpl = async () => true;
-  _runCodexImpl    = async () => '{"result":"ok"}';
-}
-
-// CodexCliProvider가 codexModule 함수를 직접 호출하므로
-// prototype-level patch를 통해 provider 동작을 제어한다.
-
-import { CodexCliProvider } from "../../lib/llm/providers/CodexCliProvider.js";
-
-const _origIsAvailable = codexModule._rawIsCodexCLIAvailable;
-const _origRunCodex    = codexModule.runCodexCLI;
-
-// node:test에서는 import가 live binding이 아니므로
-// provider 인스턴스 메서드를 직접 패치하는 방식으로 mock한다.
-
-function makeProvider() {
-  const p = new CodexCliProvider();
-  /** isAvailable: _rawIsCodexCLIAvailable 결과를 _isAvailableImpl로 대체 */
-  p.isAvailable = async () => _isAvailableImpl();
-  /** callJson 내부 runCodexCLI를 패치하기 위해 callJson을 래핑 */
-  const _origCallJson = p.callJson.bind(p);
-  p.callJson = async (prompt, options = {}) => {
-    const savedRunCodex = codexModule.runCodexCLI;
-    // 인스턴스 수준에서 callJson 재구현 (runCodexCLI mock 주입)
-    if (await p.isCircuitOpen()) {
-      throw new Error("codex-cli: circuit breaker open");
-    }
-    const finalPrompt = options.systemPrompt
-      ? `${options.systemPrompt}\n\n${prompt}`
-      : prompt;
-    try {
-      const raw    = await _runCodexImpl("", finalPrompt, options);
-      const { parseJsonResponse } = await import("../../lib/llm/util/parse-json.js");
-      const result = parseJsonResponse(raw);
-      await p.recordSuccess();
-      return result;
-    } catch (err) {
-      await p.recordFailure();
-      throw err;
-    }
-  };
-  return p;
-}
-
-import { circuitBreaker } from "../../lib/llm/util/circuit-breaker.js";
-import { redisClient }    from "../../lib/redis.js";
-
-import { after } from "node:test";
-after(async () => {
-  try { await redisClient.quit(); } catch (_) {}
+mock.module("../../lib/codex.js", {
+  exports: {
+    runCodexCLI            : (...args) => mockRunCodexCLI(...args),
+    _rawIsCodexCLIAvailable: (...args) => mockRawIsCodexCli(...args)
+  }
 });
 
-// ---------------------------------------------------------------------------
-// 테스트
-// ---------------------------------------------------------------------------
+const { CodexCliProvider } = await import("../../lib/llm/providers/CodexCliProvider.js");
+const { createProvider, listProviderNames } = await import("../../lib/llm/registry.js");
 
 describe("CodexCliProvider", () => {
-
-  afterEach(() => {
-    resetMocks();
+  beforeEach(() => {
+    mockRunCodexCLI.mock.resetCalls();
+    mockRawIsCodexCli.mock.resetCalls();
   });
 
-  // -------------------------------------------------------------------------
-  // isAvailable
-  // -------------------------------------------------------------------------
-
-  describe("isAvailable", () => {
-
-    it("codex 바이너리가 존재하면 true를 반환한다", async () => {
-      mockAvailable(async () => true);
-      const p = makeProvider();
-      assert.equal(await p.isAvailable(), true);
-    });
-
-    it("codex 바이너리가 없으면 false를 반환한다", async () => {
-      mockAvailable(async () => false);
-      const p = makeProvider();
-      assert.equal(await p.isAvailable(), false);
-    });
-
+  it("isAvailable: raw helper 결과를 그대로 반환한다", async () => {
+    mockRawIsCodexCli.mock.mockImplementationOnce(async () => true);
+    const provider = new CodexCliProvider();
+    assert.equal(await provider.isAvailable(), true);
   });
 
-  // -------------------------------------------------------------------------
-  // callText
-  // -------------------------------------------------------------------------
+  it("callText: JSON 전용 provider이므로 use callJson 에러를 던진다", async () => {
+    const provider = new CodexCliProvider();
 
-  describe("callText", () => {
-
-    it("항상 'use callJson' 에러를 던진다", async () => {
-      const p = new CodexCliProvider();
-      await assert.rejects(
-        () => p.callText("any prompt"),
-        /use callJson/
-      );
-    });
-
+    await assert.rejects(
+      () => provider.callText("hello"),
+      /use callJson/
+    );
   });
 
-  // -------------------------------------------------------------------------
-  // callJson — 성공
-  // -------------------------------------------------------------------------
-
-  describe("callJson - 성공", () => {
-
-    it("runCodexCLI가 JSON 문자열을 반환하면 파싱된 객체를 반환한다", async () => {
-      mockRunCodex(async () => '{"result":"ok","score":42}');
-      const p    = makeProvider();
-      const json = await p.callJson("test prompt");
-      assert.deepEqual(json, { result: "ok", score: 42 });
+  it("callJson: systemPrompt + JSON-only 가이드 + prompt를 helper로 전달한다", async () => {
+    mockRunCodexCLI.mock.mockImplementationOnce(async (stdinContent, prompt, options) => {
+      assert.equal(stdinContent, "");
+      assert.ok(prompt.includes("system rules"));
+      assert.ok(prompt.includes("Return one valid JSON value only."));
+      assert.ok(prompt.includes("user payload"));
+      assert.equal(options.model, "gpt-5.3-codex-spark");
+      assert.equal(options.timeoutMs, 1234);
+      return "{\"ok\":true,\"source\":\"codex-cli\"}";
     });
 
-    it("runCodexCLI가 markdown 펜스 감싼 JSON을 반환해도 파싱한다", async () => {
-      mockRunCodex(async () => "```json\n{\"key\":\"val\"}\n```");
-      const p    = makeProvider();
-      const json = await p.callJson("test prompt");
-      assert.deepEqual(json, { key: "val" });
+    const provider = new CodexCliProvider({ model: "default-model" });
+    const result = await provider.callJson("user payload", {
+      systemPrompt: "system rules",
+      model       : "gpt-5.3-codex-spark",
+      timeoutMs   : 1234
     });
 
-    it("systemPrompt가 있으면 prompt 앞에 prepend하여 호출한다", async () => {
-      let capturedPrompt = "";
-      mockRunCodex(async (_stdin, finalPrompt) => {
-        capturedPrompt = finalPrompt;
-        return '{"ok":true}';
-      });
-      const p = makeProvider();
-      await p.callJson("actual prompt", { systemPrompt: "SYSTEM" });
-      assert.match(capturedPrompt, /SYSTEM/);
-      assert.match(capturedPrompt, /actual prompt/);
-    });
-
+    assert.deepEqual(result, { ok: true, source: "codex-cli" });
   });
 
-  // -------------------------------------------------------------------------
-  // callJson — 실패
-  // -------------------------------------------------------------------------
-
-  describe("callJson - 실패", () => {
-
-    it("runCodexCLI가 throw하면 recordFailure를 호출하고 에러를 전파한다", async () => {
-      mockRunCodex(async () => { throw new Error("CLI failed"); });
-
-      const p              = makeProvider();
-      let   failureRecorded = false;
-      const _origRecord    = p.recordFailure.bind(p);
-      p.recordFailure      = async () => { failureRecorded = true; return _origRecord(); };
-
-      await assert.rejects(
-        () => p.callJson("test prompt"),
-        /CLI failed/
-      );
-      assert.equal(failureRecorded, true);
+  it("callJson: options.model이 없으면 provider config.model을 사용한다", async () => {
+    mockRunCodexCLI.mock.mockImplementationOnce(async (_stdinContent, _prompt, options) => {
+      assert.equal(options.model, "gpt-5.3-codex-spark");
+      return "{\"ok\":true}";
     });
 
-    it("runCodexCLI가 파싱 불가능한 문자열을 반환하면 에러를 던진다", async () => {
-      mockRunCodex(async () => "not json at all");
-      const p = makeProvider();
-      await assert.rejects(
-        () => p.callJson("test prompt"),
-        /failed to parse JSON/
-      );
-    });
+    const provider = new CodexCliProvider({ model: "gpt-5.3-codex-spark" });
+    const result = await provider.callJson("user payload");
 
+    assert.deepEqual(result, { ok: true });
   });
 
-  // -------------------------------------------------------------------------
-  // circuit breaker
-  // -------------------------------------------------------------------------
-
-  describe("circuit breaker", () => {
-
-    it("circuit이 열려 있으면 runCodexCLI를 호출하지 않고 에러를 던진다", async () => {
-      let runCodexCalled = false;
-      mockRunCodex(async () => { runCodexCalled = true; return '{"ok":true}'; });
-
-      const p = makeProvider();
-
-      /** circuit을 강제로 open 상태로 만든다 */
-      const _origIsCircuitOpen = p.isCircuitOpen.bind(p);
-      p.isCircuitOpen = async () => true;
-
-      await assert.rejects(
-        () => p.callJson("test prompt"),
-        /circuit breaker open/
-      );
-      assert.equal(runCodexCalled, false);
+  it("callJson: options.timeoutMs이 없으면 provider config.timeoutMs를 사용한다", async () => {
+    mockRunCodexCLI.mock.mockImplementationOnce(async (_stdinContent, _prompt, options) => {
+      assert.equal(options.timeoutMs, 2222);
+      return "{\"ok\":true}";
     });
 
-    it("circuit이 닫혀 있으면 runCodexCLI를 호출한다", async () => {
-      let runCodexCalled = false;
-      mockRunCodex(async () => { runCodexCalled = true; return '{"ok":true}'; });
+    const provider = new CodexCliProvider({ timeoutMs: 2222 });
+    const result = await provider.callJson("user payload");
 
-      const p = makeProvider();
-      p.isCircuitOpen = async () => false;
-
-      await p.callJson("test prompt");
-      assert.equal(runCodexCalled, true);
-    });
-
+    assert.deepEqual(result, { ok: true });
   });
 
+  it("callJson: circuit breaker open 상태면 helper 호출 없이 에러를 던진다", async () => {
+    const provider = new CodexCliProvider();
+    provider.isCircuitOpen = async () => true;
+
+    await assert.rejects(
+      () => provider.callJson("user payload"),
+      /circuit breaker open/
+    );
+
+    assert.equal(mockRunCodexCLI.mock.callCount(), 0);
+  });
+});
+
+describe("codex-cli registry wiring", () => {
+  it("listProviderNames: codex-cli를 노출한다", () => {
+    assert.ok(listProviderNames().includes("codex-cli"));
+  });
+
+  it("createProvider: codex-cli config로 provider 인스턴스를 생성한다", () => {
+    const provider = createProvider({
+      provider : "codex-cli",
+      model    : "gpt-5.3-codex-spark",
+      timeoutMs: 2222
+    });
+
+    assert.equal(provider?.name, "codex-cli");
+    assert.equal(provider?.config?.model, "gpt-5.3-codex-spark");
+    assert.equal(provider?.config?.timeoutMs, 2222);
+  });
 });


### PR DESCRIPTION
codex-cli 및 gpt-5.3-codex-spark 할당량 사용하고 싶어서 추가하였습니다. 감사합니다.

## 목표
- `codex-cli`가 `LLM_PRIMARY`와 `LLM_FALLBACKS`에서 `model` / `timeoutMs` 설정을 실제로 먹도록 정리합니다.
- `codex exec` 호출 contract와 관련 문서를 현재 CLI surface에 맞게 맞춥니다.

## 해결한 내용
- `lib/llm/registry.js`
  - CLI provider 생성 시 `model`, `timeoutMs`를 버리지 않고 provider config로 전달하도록 수정했습니다.
  - 기존 `copilot-cli` registry 노출은 유지했습니다.
- `lib/llm/providers/CodexCliProvider.js`
  - `callJson()`에서 JSON-only 가이드를 항상 prepend하도록 정리했습니다.
  - 요청 옵션이 없을 때 provider config의 `model`, `timeoutMs`를 fallback으로 사용하도록 수정했습니다.
- `lib/codex.js`
  - `codex exec`를 `--sandbox read-only` + `--output-last-message` 경로로 실행하도록 바꿨습니다.
  - 실패 시 stderr 우선, 필요하면 stdout까지 포함한 에러 메시지를 남기도록 보강했습니다.
- `tests/unit/codex-cli-provider.test.js`
  - provider contract, config fallback, registry wiring을 더 직접적으로 검증하는 형태로 정리했습니다.
- `docs/configuration.md`, `docs/configuration.en.md`, `docs/operations/llm-providers.md`, `docs/architecture.md`, `docs/architecture.en.md`
  - `codex-cli` 예시, provider 개수, 실행 플래그, provider 파일 경로를 실제 구현과 맞췄습니다.

## 검증
- `node --experimental-test-module-mocks --test tests/unit/codex-cli-provider.test.js`
  - `codex-cli` provider contract / registry wiring 확인
- `node --experimental-test-module-mocks --test tests/unit/llm-parse-json.test.js tests/unit/llm-fallback-chain.test.js`
  - JSON 파싱 휴리스틱 / fallback chain 회귀 확인
- `npx eslint lib/codex.js lib/llm/providers/CodexCliProvider.js lib/llm/registry.js tests/unit/codex-cli-provider.test.js`
  - 수정 범위 lint 확인
- `node --input-type=module ...`
  - 실제 `runCodexCLI('', prompt, { model: 'gpt-5.3-codex-spark', timeoutMs: 120000 })` 스모크 실행 후 `{"ok":true,"provider":"codex-cli"}` 반환 확인