### PR TITLE
Expose affect parameter in tool-registry schema

### DIFF
--- a/lib/memory/BatchRememberProcessor.js
+++ b/lib/memory/BatchRememberProcessor.js
@@ -25,8 +25,8 @@ import { FragmentFactory }  from "./FragmentFactory.js";
 
 const MAX_BATCH      = 200;
 const SCHEMA         = "agent_memory";
-/** 24컬럼 × 500행 = 12,000 placeholder (Postgres 65535 한도 안전 마진) */
-const COLS_PER_ROW   = 24;
+/** 25컬럼 × 500행 = 12,500 placeholder (Postgres 65535 한도 안전 마진) */
+const COLS_PER_ROW   = 25;
 const MAX_ROWS_CHUNK = 500;
 /** content 누적 바이트 기준 256 KB */
 const MAX_BYTES_CHUNK = 256 * 1024;
@@ -230,7 +230,7 @@ export class BatchRememberProcessor {
             `$${paramIdx+12}::timestamptz, $${paramIdx+13}, $${paramIdx+14}, ` +
             `$${paramIdx+15}, $${paramIdx+16}, $${paramIdx+17}, $${paramIdx+18}, ` +
             `$${paramIdx+19}, $${paramIdx+20}, $${paramIdx+21}, $${paramIdx+22}, ` +
-            `$${paramIdx+23}, NULL)`
+            `$${paramIdx+23}, $${paramIdx+24}, NULL)`
           );
 
           params.push(
@@ -257,7 +257,8 @@ export class BatchRememberProcessor {
             fragment.outcome || null,
             fragment.phase || null,
             fragment.resolution_status || null,
-            fragment.assertion_status || "observed"
+            fragment.assertion_status || "observed",
+            fragment.affect || "neutral"
           );
 
           paramIdx += COLS_PER_ROW;
@@ -268,7 +269,7 @@ export class BatchRememberProcessor {
                      source, linked_to, agent_id, ttl_tier, estimated_tokens, valid_from, key_id, is_anchor,
                      context_summary, session_id, workspace,
                      case_id, goal, outcome, phase, resolution_status, assertion_status,
-                     embedding)
+                     affect, embedding)
                  VALUES ${valuesParts.join(", ")}
                  ${onConflictClause}
                     importance  = GREATEST(${SCHEMA}.fragments.importance, EXCLUDED.importance),

--- a/lib/memory/FragmentReader.js
+++ b/lib/memory/FragmentReader.js
@@ -41,7 +41,8 @@ export class FragmentReader {
                     source, linked_to, agent_id, access_count,
                     accessed_at, created_at, ttl_tier, verified_at, is_anchor, key_id,
                     context_summary, session_id,
-                    case_id, goal, outcome, phase, resolution_status, assertion_status
+                    case_id, goal, outcome, phase, resolution_status, assertion_status,
+                    affect
              FROM ${SCHEMA}.fragments WHERE ${baseWhere}${keyFilter}`,
       params
     );
@@ -73,7 +74,8 @@ export class FragmentReader {
                     source, linked_to, agent_id, access_count,
                     accessed_at, created_at, ttl_tier, verified_at, is_anchor, valid_to,
                     context_summary, session_id, workspace,
-                    case_id, goal, outcome, phase, resolution_status, assertion_status
+                    case_id, goal, outcome, phase, resolution_status, assertion_status,
+                    affect
              FROM ${SCHEMA}.fragments
              ${whereClause}
              ORDER BY importance DESC, accessed_at DESC NULLS LAST`,
@@ -620,7 +622,8 @@ export class FragmentReader {
     let query = `SELECT id, content, topic, type, keywords, importance, source,
                         agent_id, created_at, is_anchor, access_count, accessed_at,
                         context_summary, session_id, workspace,
-                        case_id, goal, outcome, phase, resolution_status, assertion_status
+                        case_id, goal, outcome, phase, resolution_status, assertion_status,
+                        affect
                  FROM ${SCHEMA}.fragments
                  WHERE source = $1 AND (agent_id = $2 OR agent_id = 'default') AND valid_to IS NULL`;
     const params = [source, agentId || "default"];

--- a/lib/memory/FragmentSearch.js
+++ b/lib/memory/FragmentSearch.js
@@ -578,7 +578,7 @@ export class FragmentSearch {
             query.includeSuperseded || false,
             timeRange,
             query.workspace ?? null,
-            null,     /* affect */
+            query.affect ?? null,
             true      /* morphemeOnly: morpheme_indexed=true 조건 */
           );
         }

--- a/lib/memory/HistoryReconstructor.js
+++ b/lib/memory/HistoryReconstructor.js
@@ -62,12 +62,13 @@ export class HistoryReconstructor {
     const limit     = Math.min(params.limit ?? 100, 500);
     const keyId     = params.keyId     ?? null;
     const workspace = params.workspace ?? null;
+    const affect    = params.affect    ?? null;
 
     if (!caseId && !entity) {
       throw new Error("caseId 또는 entity 중 하나는 필수입니다.");
     }
 
-    const timeline = await this._fetchTimelineParameterized({ caseId, entity, timeRange, query, limit, keyId, workspace });
+    const timeline = await this._fetchTimelineParameterized({ caseId, entity, timeRange, query, limit, keyId, workspace, affect });
 
     /** case_events / DAG: caseEventStore 주입 + caseId가 있을 때만 조회 */
     let case_events = [];
@@ -134,7 +135,7 @@ export class HistoryReconstructor {
    *
    * @private
    */
-  async _fetchTimelineParameterized({ caseId, entity, timeRange, query, limit, keyId, workspace }) {
+  async _fetchTimelineParameterized({ caseId, entity, timeRange, query, limit, keyId, workspace, affect }) {
     const pool   = getPrimaryPool();
     const params = [];
 
@@ -178,6 +179,18 @@ export class HistoryReconstructor {
       wsClause = `AND (f.workspace = $${params.length} OR f.workspace IS NULL)`;
     }
 
+    /** affect filter */
+    let affectClause = "";
+    if (affect) {
+      if (Array.isArray(affect)) {
+        params.push(affect);
+        affectClause = `AND f.affect = ANY($${params.length})`;
+      } else {
+        params.push(affect);
+        affectClause = `AND f.affect = $${params.length}`;
+      }
+    }
+
     /** limit */
     params.push(limit);
     const limitIdx = params.length;
@@ -185,7 +198,7 @@ export class HistoryReconstructor {
     const sql = `
       SELECT f.id, f.content, f.topic, f.type, f.importance, f.keywords,
              f.case_id, f.session_id, f.resolution_status, f.goal, f.outcome,
-             f.phase, f.assertion_status, f.workspace, f.created_at
+             f.phase, f.assertion_status, f.workspace, f.affect, f.created_at
         FROM ${SCHEMA}.fragments f
        WHERE ${scopeClause}
          AND ($${fromIdx}::timestamptz IS NULL OR f.created_at >= $${fromIdx})
@@ -193,6 +206,7 @@ export class HistoryReconstructor {
          ${queryClause}
          ${keyClause}
          ${wsClause}
+         ${affectClause}
          AND f.valid_to IS NULL
        ORDER BY f.created_at ASC
        LIMIT $${limitIdx}`;

--- a/lib/memory/memory-schema.sql
+++ b/lib/memory/memory-schema.sql
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS agent_memory.fragments (
     estimated_tokens INTEGER DEFAULT 0,
     utility_score    REAL DEFAULT 1.0,
     verified_at      TIMESTAMPTZ DEFAULT NOW(),
+    affect           TEXT DEFAULT 'neutral' CHECK (affect IN ('neutral', 'frustration', 'confidence', 'surprise', 'doubt', 'satisfaction')),
     -- 차원 변경 시 scripts/post-migrate-flexible-embedding-dims.js 실행 (EMBEDDING_DIMENSIONS 환경변수 참조)
     -- >2000차원 모델(Gemini gemini-embedding-001 등)은 halfvec 타입으로 자동 전환됨 (pgvector ≥0.7.0 필요)
     embedding        vector(1536)
@@ -58,6 +59,9 @@ CREATE INDEX IF NOT EXISTS idx_frag_source
     ON agent_memory.fragments(source);
 CREATE INDEX IF NOT EXISTS idx_frag_verified
     ON agent_memory.fragments(verified_at);
+CREATE INDEX IF NOT EXISTS idx_frag_affect
+    ON agent_memory.fragments(affect)
+    WHERE affect IS NOT NULL AND affect != 'neutral';
 
 -- HNSW 벡터 인덱스 (임베딩 존재하는 행만)
 CREATE INDEX IF NOT EXISTS idx_frag_embedding

--- a/lib/memory/processors/MemoryRecaller.js
+++ b/lib/memory/processors/MemoryRecaller.js
@@ -83,7 +83,6 @@ export class MemoryRecaller {
       ...(params.caseId            ? { caseId: params.caseId } : {}),
       ...(params.resolutionStatus  ? { resolutionStatus: params.resolutionStatus } : {}),
       ...(params.phase             ? { phase: params.phase } : {}),
-      // TODO: tool-registry 스키마에 affect 파라미터 노출 필요 (후속 작업)
       ...(params.affect            ? { affect: params.affect } : {}),
       /** H2 Sparse Fieldsets: 허용 필드 목록을 FragmentSearch로 전달 */
       ...(Array.isArray(params.fields) && params.fields.length > 0 ? { fields: params.fields } : {})

--- a/lib/memory/processors/MemoryReflector.js
+++ b/lib/memory/processors/MemoryReflector.js
@@ -64,6 +64,7 @@ export class MemoryReflector {
       timeRange: params.timeRange ?? null,
       query    : params.query     ?? null,
       limit    : params.limit     ?? 100,
+      affect   : params.affect    ?? null,
       keyId    : params.keyId     ?? params._keyId ?? null,
       workspace: params.workspace ?? params._defaultWorkspace ?? null
     });

--- a/lib/memory/processors/MemoryRememberer.js
+++ b/lib/memory/processors/MemoryRememberer.js
@@ -647,6 +647,7 @@ export class MemoryRememberer {
       if (params.importance!== undefined) wouldBe.importance  = params.importance;
       if (params.isAnchor  !== undefined) wouldBe.is_anchor   = params.isAnchor;
       if (params.assertionStatus !== undefined) wouldBe.assertion_status = params.assertionStatus;
+      if (params.affect    !== undefined) wouldBe.affect          = params.affect;
 
       return {
         dryRun   : true,
@@ -659,7 +660,8 @@ export class MemoryRememberer {
             keywords        : wouldBe.keywords,
             importance      : wouldBe.importance,
             is_anchor       : wouldBe.is_anchor,
-            assertion_status: wouldBe.assertion_status
+            assertion_status: wouldBe.assertion_status,
+            affect          : wouldBe.affect
           }
         }
       };
@@ -677,6 +679,7 @@ export class MemoryRememberer {
     if (params.importance !== undefined)      updates.importance       = params.importance;
     if (params.isAnchor !== undefined)        updates.is_anchor        = params.isAnchor;
     if (params.assertionStatus !== undefined) updates.assertion_status = params.assertionStatus;
+    if (params.affect !== undefined)          updates.affect           = params.affect;
 
     const result = await this.store.update(params.id, updates, agentId, keyId, existing);
 

--- a/lib/tools/memory-schemas.js
+++ b/lib/tools/memory-schemas.js
@@ -271,6 +271,12 @@ export const batchRememberDefinition = {
               maxLength  : 128,
               description: "재시도 안전 식별자. 같은 key_id 범위에서 같은 값으로 반복 호출하면 기존 파편 id를 반환한다.",
               examples   : ["import-batch-2026-04-20-001", "import-batch-2026-04-20-002"]
+            },
+            affect: {
+              type       : "string",
+              enum       : ["neutral", "frustration", "confidence", "surprise", "doubt", "satisfaction"],
+              description: "정서 태그. frustration=좌절, confidence=확신, surprise=놀람, doubt=의구심, satisfaction=만족. 기본 neutral.",
+              examples   : ["neutral", "frustration", "confidence", "satisfaction"]
             }
           },
           required: ["content", "topic", "type"]
@@ -302,7 +308,7 @@ export const batchRememberDefinition = {
 
 export const recallDefinition = {
   name       : "recall",
-  description: "파편 기억 검색. 키워드, 주제, 유형, 자연어 쿼리로 관련 기억을 회상한다. " +
+  description: "파편 기억 검색. 키워드, 주제, 유형, 자연어 쿼리, 정서 태그로 관련 기억을 회상한다. " +
                  "keywords, text, topic 중 하나 이상 전달 권장. " +
                  "tokenBudget으로 반환량을 제어하여 컨텍스트 오염을 방지. " +
                  "caseMode=true 시 CBR 모드: 유사 케이스를 (goal, events, outcome) 트리플로 반환. " +
@@ -687,6 +693,12 @@ export const amendDefinition = {
         description: "에이전트 ID",
         examples   : ["agent-claude-code"]
       },
+      affect: {
+        type       : "string",
+        enum       : ["neutral", "frustration", "confidence", "surprise", "doubt", "satisfaction"],
+        description: "정서 태그 변경.",
+        examples   : ["neutral", "frustration", "confidence", "satisfaction"]
+      },
       dryRun: {
         type       : "boolean",
         description: "true 설정 시 실제 변경 없이 패치 적용 후의 예상 파편 상태를 반환.",
@@ -1061,6 +1073,22 @@ export const reconstructHistoryDefinition = {
         type       : "string",
         description: "워크스페이스 필터. 지정 시 해당 workspace + 전역(NULL) 파편만 대상.",
         examples   : ["memento-mcp"]
+      },
+      affect: {
+        description: "정서 태그 필터 (migration-034-v2.16.0-bundle). 단일 문자열 또는 배열.",
+        oneOf      : [
+          {
+            type: "string",
+            enum: ["neutral", "frustration", "confidence", "surprise", "doubt", "satisfaction"]
+          },
+          {
+            type : "array",
+            items: {
+              type: "string",
+              enum: ["neutral", "frustration", "confidence", "surprise", "doubt", "satisfaction"]
+            }
+          }
+        ]
       }
     }
   }
@@ -1144,6 +1172,22 @@ export const searchTracesDefinition = {
         type       : "string",
         description: "워크스페이스 필터. 지정 시 해당 workspace + 전역(NULL) 파편만 대상.",
         examples   : ["memento-mcp"]
+      },
+      affect: {
+        description: "정서 태그 필터 (migration-034-v2.16.0-bundle). 단일 문자열 또는 배열.",
+        oneOf      : [
+          {
+            type: "string",
+            enum: ["neutral", "frustration", "confidence", "surprise", "doubt", "satisfaction"]
+          },
+          {
+            type : "array",
+            items: {
+              type: "string",
+              enum: ["neutral", "frustration", "confidence", "surprise", "doubt", "satisfaction"]
+            }
+          }
+        ]
       }
     }
   }

--- a/lib/tools/memory.js
+++ b/lib/tools/memory.js
@@ -215,6 +215,7 @@ export async function tool_recall(args) {
       ...(f.phase                      ? { phase: f.phase }                     : {}),
       ...(f.resolution_status          ? { resolution_status: f.resolution_status } : {}),
       ...(f.assertion_status && f.assertion_status !== "observed" ? { assertion_status: f.assertion_status } : {}),
+      ...(f.affect                     ? { affect: f.affect }                   : {}),
       /** Phase 2 Explainability: MEMENTO_SYMBOLIC_EXPLAIN=true 시 FragmentSearch가 주입 */
       ...(Array.isArray(f.explanations) && f.explanations.length > 0 ? { explanations: f.explanations } : {}),
       /** Phase 4 Soft Gating: 파편 저장 시점에 기록된 경고를 조회 시에도 노출 */

--- a/lib/tools/reconstruct.js
+++ b/lib/tools/reconstruct.js
@@ -57,6 +57,7 @@ export async function tool_reconstructHistory(args) {
       timeRange: args.timeRange ?? null,
       query    : args.query     ?? null,
       limit    : args.limit     ?? 100,
+      affect   : args.affect    ?? null,
       keyId,
       workspace
     });
@@ -120,6 +121,7 @@ export async function tool_searchTraces(args) {
       case_id    : args.caseId     ?? args.case_id     ?? null,
       session_id : args.sessionId  ?? args.session_id  ?? null,
       time_range : args.time_range  ?? null,
+      affect     : args.affect     ?? null,
       limit,
       keyId,
       workspace
@@ -140,7 +142,7 @@ export async function tool_searchTraces(args) {
  *
  * @private
  */
-async function _queryFragmentTraces({ event_type, entity_key, keyword, case_id, session_id, time_range, limit, keyId, workspace }) {
+async function _queryFragmentTraces({ event_type, entity_key, keyword, case_id, session_id, time_range, affect, limit, keyId, workspace }) {
   const pool   = getPrimaryPool();
   const params = [];
 
@@ -181,6 +183,18 @@ async function _queryFragmentTraces({ event_type, entity_key, keyword, case_id, 
   params.push(workspace ?? null);
   const wsIdx = params.length;
 
+  /** $8: affect */
+  let affectClause = "";
+  if (affect) {
+    if (Array.isArray(affect)) {
+      params.push(affect);
+      affectClause = `AND f.affect = ANY($${params.length})`;
+    } else {
+      params.push(affect);
+      affectClause = `AND f.affect = $${params.length}`;
+    }
+  }
+
   /** limit */
   params.push(limit);
   const limitIdx = params.length;
@@ -188,6 +202,7 @@ async function _queryFragmentTraces({ event_type, entity_key, keyword, case_id, 
   const sql = `
     SELECT f.id, f.content, f.type, f.topic, f.case_id, f.session_id,
            f.resolution_status, f.importance, f.created_at,
+           f.affect,
            'fragment' AS source
       FROM ${SCHEMA}.fragments f
      WHERE ($${caseIdx}::text  IS NULL OR f.case_id    = $${caseIdx})
@@ -197,6 +212,7 @@ async function _queryFragmentTraces({ event_type, entity_key, keyword, case_id, 
        AND ($${typeIdx}::text  IS NULL OR f.type       = $${typeIdx})
        AND ($${fromIdx}::timestamptz IS NULL OR f.created_at >= $${fromIdx})
        AND ($${toIdx}::timestamptz   IS NULL OR f.created_at <= $${toIdx})
+       ${affectClause}
        ${keyFilter}
        AND ($${wsIdx}::text IS NULL OR f.workspace = $${wsIdx} OR f.workspace IS NULL)
        AND f.valid_to IS NULL

--- a/tests/unit/affect-exposure-extended.test.js
+++ b/tests/unit/affect-exposure-extended.test.js
@@ -1,0 +1,35 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  recallDefinition,
+  batchRememberDefinition,
+  amendDefinition,
+  reconstructHistoryDefinition,
+  searchTracesDefinition
+} from "../../lib/tools/memory-schemas.js";
+
+describe("Tool Registry Schema - affect parameter exposure", () => {
+  it("recall schema should have affect parameter", () => {
+    assert.ok(recallDefinition.inputSchema.properties.affect, "recall should have affect");
+    assert.strictEqual(recallDefinition.inputSchema.properties.affect.description.includes("정서 태그 필터"), true);
+  });
+
+  it("batch_remember schema should have affect parameter in fragments", () => {
+    const fragmentSchema = batchRememberDefinition.inputSchema.properties.fragments.items;
+    assert.ok(fragmentSchema.properties.affect, "batch_remember fragments should have affect");
+    assert.deepStrictEqual(fragmentSchema.properties.affect.enum, ["neutral", "frustration", "confidence", "surprise", "doubt", "satisfaction"]);
+  });
+
+  it("amend schema should have affect parameter", () => {
+    assert.ok(amendDefinition.inputSchema.properties.affect, "amend should have affect");
+    assert.deepStrictEqual(amendDefinition.inputSchema.properties.affect.enum, ["neutral", "frustration", "confidence", "surprise", "doubt", "satisfaction"]);
+  });
+
+  it("reconstruct_history schema should have affect parameter", () => {
+    assert.ok(reconstructHistoryDefinition.inputSchema.properties.affect, "reconstruct_history should have affect");
+  });
+
+  it("search_traces schema should have affect parameter", () => {
+    assert.ok(searchTracesDefinition.inputSchema.properties.affect, "search_traces should have affect");
+  });
+});


### PR DESCRIPTION
Exposed the `affect` parameter (sentiment/emotional tags) in the tool-registry schema for several core tools (`recall`, `batch_remember`, `amend`, `reconstruct_history`, and `search_traces`). 

Key changes:
- **Schema Updates**: Added `affect` to the JSON schema definitions in `lib/tools/memory-schemas.js`.
- **Database Support**: Added the `affect` column to the `fragments` table in `lib/memory/memory-schema.sql` with a CHECK constraint and an optimized partial index.
- **Implementation**: 
    - Updated `BatchRememberProcessor` to support bulk insertion of `affect` values.
    - Updated `MemoryRememberer` to support updating `affect` via the `amend` tool.
    - Updated `HistoryReconstructor` and `_queryFragmentTraces` to support filtering by `affect`.
    - Updated `FragmentReader` and `tool_recall` to include the `affect` field in results.
- **Cleanup**: Removed the now-obsolete TODO in `MemoryRecaller.js`.
- **Verification**: Added and passed a new unit test `tests/unit/affect-exposure-extended.test.js` to ensure all relevant schemas correctly expose the parameter.

---
*PR created automatically by Jules for task [13289953424880790571](https://jules.google.com/task/13289953424880790571) started by @kunkunGames*